### PR TITLE
Fix for #1997 gasGenerators incorrectly limiting output

### DIFF
--- a/src/main/java/mekanism/generators/common/tile/TileEntityGasGenerator.java
+++ b/src/main/java/mekanism/generators/common/tile/TileEntityGasGenerator.java
@@ -74,7 +74,12 @@ public class TileEntityGasGenerator extends TileEntityGenerator implements IGasH
 				if(gasType != null && FuelHandler.getFuel(gasType) != null)
 				{
 					GasStack removed = GasTransmission.removeGas(inventory[0], gasType, fuelTank.getNeeded());
-					fuelTank.receive(removed, true);
+					boolean isTankEmpty = (fuelTank.getGas() == null);
+					int fuelReceived = fuelTank.receive(removed, true);
+					if (fuelReceived > 0 && isTankEmpty)
+					{
+						output = FuelHandler.getFuel(fuelTank.getGas().getGas()).energyPerTick * 2;
+					}
 				}
 			}
 
@@ -95,6 +100,7 @@ public class TileEntityGasGenerator extends TileEntityGenerator implements IGasH
 					{
 						burnTicks = fuel.burnTicks - 1;
 						generationRate = fuel.energyPerTick;
+						//output = generationRate * 2;
 						fuelTank.draw(1, true);
 						setEnergy(getEnergy() + generationRate);
 					}
@@ -208,6 +214,7 @@ public class TileEntityGasGenerator extends TileEntityGenerator implements IGasH
 		}
 		
 		generationRate = dataStream.readDouble();
+		output = dataStream.readDouble();
 	}
 
 	@Override
@@ -226,6 +233,7 @@ public class TileEntityGasGenerator extends TileEntityGenerator implements IGasH
 		}
 		
 		data.add(generationRate);
+		data.add(output);
 		
 		return data;
 	}
@@ -233,9 +241,14 @@ public class TileEntityGasGenerator extends TileEntityGenerator implements IGasH
 	@Override
 	public int receiveGas(ForgeDirection side, GasStack stack)
 	{
-		if(fuelTank.getGas() == null || fuelTank.getGas().isGasEqual(stack))
+		boolean isTankEmpty = (fuelTank.getGas() == null);
+		if (isTankEmpty || fuelTank.getGas().isGasEqual(stack))
 		{
-			return fuelTank.receive(stack, true);
+			int fuelReceived = fuelTank.receive(stack, true);
+			if (isTankEmpty && fuelReceived > 0) {
+				output = FuelHandler.getFuel(fuelTank.getGas().getGas()).energyPerTick * 2;
+			}
+			return fuelReceived;
 		}
 
 		return 0;
@@ -247,6 +260,10 @@ public class TileEntityGasGenerator extends TileEntityGenerator implements IGasH
 		super.readFromNBT(nbtTags);
 
 		fuelTank.read(nbtTags.getCompoundTag("fuelTank"));
+		FuelGas fuel = FuelHandler.getFuel(fuelTank.getGas().getGas());
+		if (fuel != null) {
+			output = fuel.energyPerTick * 2;
+		}
 	}
 
 	@Override

--- a/src/main/java/mekanism/generators/common/tile/TileEntityGasGenerator.java
+++ b/src/main/java/mekanism/generators/common/tile/TileEntityGasGenerator.java
@@ -100,7 +100,6 @@ public class TileEntityGasGenerator extends TileEntityGenerator implements IGasH
 					{
 						burnTicks = fuel.burnTicks - 1;
 						generationRate = fuel.energyPerTick;
-						//output = generationRate * 2;
 						fuelTank.draw(1, true);
 						setEnergy(getEnergy() + generationRate);
 					}


### PR DESCRIPTION
This change fixes the issue I was seeing where gasGenerators are limiting energy output based on hydrogen burning even though ethylene, when burned, produces more energy. This fix only checks and sets the output when a new fuel is first put into the generator, or when the when the generator is loaded up in the world.