### PR TITLE
Fixed server crash in 7.1.2

### DIFF
--- a/src/main/java/mekanism/generators/common/block/BlockGenerator.java
+++ b/src/main/java/mekanism/generators/common/block/BlockGenerator.java
@@ -134,6 +134,7 @@ public class BlockGenerator extends BlockContainer implements ISpecialBounds, IP
 	}
 
 	@Override
+	@SideOnly(Side.CLIENT)
 	public int getLightValue(IBlockAccess world, int x, int y, int z)
 	{
 		if(MekanismGeneratorsClient.enableAmbientLighting)


### PR DESCRIPTION
This fixes that the server crashes due to that the in enableAmbientLighting and ambientLightingLevel MekanismGeneratorsClient is client only.

I'm not sure if this is the right way to fix this.

I've confirmed that this solves the crash problem.