### PR TITLE
Shift-click items to top (fill) slot

### DIFF
--- a/src/main/java/mekanism/common/inventory/container/ContainerGasTank.java
+++ b/src/main/java/mekanism/common/inventory/container/ContainerGasTank.java
@@ -69,25 +69,15 @@ public class ContainerGasTank extends Container
 			{
 				if(slotID != 0 && slotID != 1)
 				{
-					if(!mergeItemStack(slotStack, 1, 2, false))
-					{
-						if(!mergeItemStack(slotStack, 0, 1, false))
-						{
-							return null;
-						}
-					}
-				}
-				else if(slotID == 1)
-				{
 					if(!mergeItemStack(slotStack, 0, 1, false))
 					{
-						if(!mergeItemStack(slotStack, 2, inventorySlots.size(), false))
+						if(!mergeItemStack(slotStack, 1, 2, false))
 						{
 							return null;
 						}
 					}
 				}
-				else if(slotID == 0)
+				else
 				{
 					if(!mergeItemStack(slotStack, 2, inventorySlots.size(), true))
 					{


### PR DESCRIPTION
I don't think a day goes by where I don't shift-click my jetpack into the gas tank and when it ends up in the bottom slot I cry out in pain :cry: 

If 99.9999% of the time you open the gas tank to manually fill a jetpack or scuba tank, it makes sense to have items shift-click into the top slot rather than the bottom one. (And items in either of the gas tank slots will shift-click to the player inventory now as well.)