### PR TITLE
Fix for setting generator output when ethylene already in tank when plac...

### DIFF
--- a/src/main/java/mekanism/generators/common/tile/TileEntityGasGenerator.java
+++ b/src/main/java/mekanism/generators/common/tile/TileEntityGasGenerator.java
@@ -312,6 +312,12 @@ public class TileEntityGasGenerator extends TileEntityGenerator implements IGasH
 		if(itemStack.stackTagCompound.hasKey("fuelTank"))
 		{
 			fuelTank.read(itemStack.stackTagCompound.getCompoundTag("fuelTank"));
+			
+			// update energy output based on any existing fuel in tank
+			FuelGas fuel = FuelHandler.getFuel(fuelTank.getGas().getGas());
+			if (fuel != null) {
+				output = fuel.energyPerTick * 2;
+			}
 		}
 	}
 }


### PR DESCRIPTION
If a gas generator entity has ethylene in the tank when it is placed, the max output will not be calculated correctly until a restart or the tank is emptied