### PR TITLE
New config entries

### DIFF
--- a/src/main/java/mekanism/common/CommonProxy.java
+++ b/src/main/java/mekanism/common/CommonProxy.java
@@ -206,6 +206,7 @@ public class CommonProxy
 		Mekanism.FROM_H2 = Mekanism.configuration.get(Configuration.CATEGORY_GENERAL, "HydrogenEnergyDensity", 200D, "THIS DETERMINES ELECTROLYTIC SEPARATOR USAGE").getDouble(200D);
 		Mekanism.ETHENE_BURN_TIME = Mekanism.configuration.get(Configuration.CATEGORY_GENERAL, "EthyleneBurnTime", 40).getInt(40);
 		Mekanism.ENERGY_PER_REDSTONE = Mekanism.configuration.get(Configuration.CATEGORY_GENERAL, "EnergyPerRedstone", 10000D).getDouble(10000D);
+		Mekanism.ATOMICDISASSEM_ENERGY_USAGE = Mekanism.configuration.get(Configuration.CATEGORY_GENERAL, "AtomicDisassemblerEnergyUsage", 10).getInt(10);
 		Mekanism.VOICE_PORT = Mekanism.configuration.get(Configuration.CATEGORY_GENERAL, "VoicePort", 36123, null, 1, 65535).getInt();
 		//If this is less than 1, upgrades make machines worse. If less than 0, I don't even know.
 		Mekanism.maxUpgradeMultiplier = Mekanism.configuration.get(Configuration.CATEGORY_GENERAL, "UpgradeModifier", 10, null, 1, Integer.MAX_VALUE).getInt();

--- a/src/main/java/mekanism/common/CommonProxy.java
+++ b/src/main/java/mekanism/common/CommonProxy.java
@@ -204,6 +204,7 @@ public class CommonProxy
 		Mekanism.FROM_TE = Mekanism.configuration.get(Configuration.CATEGORY_GENERAL, "JoulesToRF", 2.5D).getDouble(25D);
 		Mekanism.TO_TE = Mekanism.configuration.get(Configuration.CATEGORY_GENERAL, "RFToJoules", .4D).getDouble(.04D);
 		Mekanism.FROM_H2 = Mekanism.configuration.get(Configuration.CATEGORY_GENERAL, "HydrogenEnergyDensity", 200D, "THIS DETERMINES ELECTROLYTIC SEPARATOR USAGE").getDouble(200D);
+		Mekanism.ETHENE_BURN_TIME = Mekanism.configuration.get(Configuration.CATEGORY_GENERAL, "EthyleneBurnTime", 40).getInt(40);
 		Mekanism.ENERGY_PER_REDSTONE = Mekanism.configuration.get(Configuration.CATEGORY_GENERAL, "EnergyPerRedstone", 10000D).getDouble(10000D);
 		Mekanism.VOICE_PORT = Mekanism.configuration.get(Configuration.CATEGORY_GENERAL, "VoicePort", 36123, null, 1, 65535).getInt();
 		//If this is less than 1, upgrades make machines worse. If less than 0, I don't even know.

--- a/src/main/java/mekanism/common/Mekanism.java
+++ b/src/main/java/mekanism/common/Mekanism.java
@@ -331,6 +331,7 @@ public class Mekanism
 	public static double FROM_TE;
 	public static double FROM_UE = 1/TO_UE;
 	public static int ETHENE_BURN_TIME = 40;
+	public static int ATOMICDISASSEM_ENERGY_USAGE = 10;
 
 	public static boolean blacklistBC;
 	public static boolean blacklistIC2;

--- a/src/main/java/mekanism/common/Mekanism.java
+++ b/src/main/java/mekanism/common/Mekanism.java
@@ -330,6 +330,7 @@ public class Mekanism
 	public static double FROM_IC2;
 	public static double FROM_TE;
 	public static double FROM_UE = 1/TO_UE;
+	public static int ETHENE_BURN_TIME = 40;
 
 	public static boolean blacklistBC;
 	public static boolean blacklistIC2;

--- a/src/main/java/mekanism/common/item/ItemAtomicDisassembler.java
+++ b/src/main/java/mekanism/common/item/ItemAtomicDisassembler.java
@@ -9,8 +9,8 @@ import java.util.Set;
 import mekanism.api.Coord4D;
 import mekanism.api.EnumColor;
 import mekanism.api.ListUtils;
+import mekanism.common.Mekanism;
 import mekanism.common.util.MekanismUtils;
-
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.EntityLivingBase;
@@ -28,8 +28,7 @@ import cpw.mods.fml.common.eventhandler.Event.Result;
 
 public class ItemAtomicDisassembler extends ItemEnergized
 {
-	public double ENERGY_USAGE = 10;
-	public double HOE_USAGE = 100;
+	public double HOE_USAGE = 10 * Mekanism.ATOMICDISASSEM_ENERGY_USAGE;
 
 	public ItemAtomicDisassembler()
 	{
@@ -80,10 +79,10 @@ public class ItemAtomicDisassembler extends ItemEnergized
 	{
 		if(block.getBlockHardness(world, x, y, z) != 0.0D)
 		{
-			setEnergy(itemstack, getEnergy(itemstack) - (ENERGY_USAGE*getEfficiency(itemstack)));
+			setEnergy(itemstack, getEnergy(itemstack) - (Mekanism.ATOMICDISASSEM_ENERGY_USAGE*getEfficiency(itemstack)));
 		}
 		else {
-			setEnergy(itemstack, getEnergy(itemstack) - (ENERGY_USAGE*(getEfficiency(itemstack))/2));
+			setEnergy(itemstack, getEnergy(itemstack) - (Mekanism.ATOMICDISASSEM_ENERGY_USAGE*(getEfficiency(itemstack))/2));
 		}
 
 		return true;
@@ -125,7 +124,7 @@ public class ItemAtomicDisassembler extends ItemEnergized
 
 				for(Coord4D coord : found)
 				{
-					if(coord.equals(orig) || getEnergy(itemstack) < (ENERGY_USAGE*getEfficiency(itemstack)))
+					if(coord.equals(orig) || getEnergy(itemstack) < (Mekanism.ATOMICDISASSEM_ENERGY_USAGE*getEfficiency(itemstack)))
 					{
 						continue;
 					}
@@ -138,7 +137,7 @@ public class ItemAtomicDisassembler extends ItemEnergized
 					block2.breakBlock(player.worldObj, coord.xCoord, coord.yCoord, coord.zCoord, block, meta);
 					block2.dropBlockAsItem(player.worldObj, coord.xCoord, coord.yCoord, coord.zCoord, meta, 0);
 
-					setEnergy(itemstack, getEnergy(itemstack) - (ENERGY_USAGE*getEfficiency(itemstack)));
+					setEnergy(itemstack, getEnergy(itemstack) - (Mekanism.ATOMICDISASSEM_ENERGY_USAGE*getEfficiency(itemstack)));
 				}
 			}
 		}

--- a/src/main/java/mekanism/common/network/PacketConfigSync.java
+++ b/src/main/java/mekanism/common/network/PacketConfigSync.java
@@ -43,6 +43,7 @@ public class PacketConfigSync implements IMessageHandler<ConfigSyncMessage, IMes
 			dataStream.writeDouble(Mekanism.FROM_H2);
 			dataStream.writeInt(Mekanism.ETHENE_BURN_TIME);
 			dataStream.writeDouble(Mekanism.ENERGY_PER_REDSTONE);
+			dataStream.writeInt(Mekanism.ATOMICDISASSEM_ENERGY_USAGE);
 			dataStream.writeInt(Mekanism.VOICE_PORT);
 			dataStream.writeInt(Mekanism.maxUpgradeMultiplier);
 			dataStream.writeInt(Mekanism.activeType.ordinal());
@@ -98,6 +99,7 @@ public class PacketConfigSync implements IMessageHandler<ConfigSyncMessage, IMes
 			Mekanism.FROM_H2 = dataStream.readDouble();
 			Mekanism.ETHENE_BURN_TIME = dataStream.readInt();
 			Mekanism.ENERGY_PER_REDSTONE = dataStream.readDouble();
+			Mekanism.ATOMICDISASSEM_ENERGY_USAGE = dataStream.readInt();
 			Mekanism.VOICE_PORT = dataStream.readInt();
 			Mekanism.maxUpgradeMultiplier = dataStream.readInt();
 			Mekanism.activeType = EnergyType.values()[dataStream.readInt()];

--- a/src/main/java/mekanism/common/network/PacketConfigSync.java
+++ b/src/main/java/mekanism/common/network/PacketConfigSync.java
@@ -41,6 +41,7 @@ public class PacketConfigSync implements IMessageHandler<ConfigSyncMessage, IMes
 			dataStream.writeDouble(Mekanism.FROM_TE);
 			dataStream.writeDouble(Mekanism.TO_TE);
 			dataStream.writeDouble(Mekanism.FROM_H2);
+			dataStream.writeInt(Mekanism.ETHENE_BURN_TIME);
 			dataStream.writeDouble(Mekanism.ENERGY_PER_REDSTONE);
 			dataStream.writeInt(Mekanism.VOICE_PORT);
 			dataStream.writeInt(Mekanism.maxUpgradeMultiplier);
@@ -95,6 +96,7 @@ public class PacketConfigSync implements IMessageHandler<ConfigSyncMessage, IMes
 			Mekanism.FROM_TE = dataStream.readDouble();
 			Mekanism.TO_TE = dataStream.readDouble();
 			Mekanism.FROM_H2 = dataStream.readDouble();
+			Mekanism.ETHENE_BURN_TIME = dataStream.readInt();
 			Mekanism.ENERGY_PER_REDSTONE = dataStream.readDouble();
 			Mekanism.VOICE_PORT = dataStream.readInt();
 			Mekanism.maxUpgradeMultiplier = dataStream.readInt();

--- a/src/main/java/mekanism/generators/common/MekanismGenerators.java
+++ b/src/main/java/mekanism/generators/common/MekanismGenerators.java
@@ -143,7 +143,7 @@ public class MekanismGenerators implements IModule
 			" O ", "OAO", "ECE", Character.valueOf('O'), "ingotOsmium", Character.valueOf('A'), Mekanism.EnrichedAlloy, Character.valueOf('E'), Mekanism.EnergyTablet.getUnchargedItem(), Character.valueOf('C'), "circuitBasic"
 		}));
 
-		FuelHandler.addGas(GasRegistry.getGas("ethene"), 40, Mekanism.FROM_H2 + bioGeneration * 80); //1mB hydrogen + 2*bioFuel/tick*200ticks/100mB * 20x efficiency bonus
+		FuelHandler.addGas(GasRegistry.getGas("ethene"), Mekanism.ETHENE_BURN_TIME, Mekanism.FROM_H2 + bioGeneration * 2 * Mekanism.ETHENE_BURN_TIME); //1mB hydrogen + 2*bioFuel/tick*2000ticks/100mB * 2x efficiency bonus
 
 	}
 	


### PR DESCRIPTION
I added two new config entries. 
One for the atomic disassembler energy usage for request #2146.
The second for the ethylene burn time as I always felt that ethylene produced too much gross power compared to how much is produced from a single piece of wheat. Lowering to burn time from 40 to 20 or even 10 seemed to make a better balance on the servers I have run.