### PR TITLE
Makes Upgrades Configurable

### DIFF
--- a/src/main/java/mekanism/common/CommonProxy.java
+++ b/src/main/java/mekanism/common/CommonProxy.java
@@ -207,6 +207,8 @@ public class CommonProxy
 		Mekanism.ETHENE_BURN_TIME = Mekanism.configuration.get(Configuration.CATEGORY_GENERAL, "EthyleneBurnTime", 40).getInt(40);
 		Mekanism.ENERGY_PER_REDSTONE = Mekanism.configuration.get(Configuration.CATEGORY_GENERAL, "EnergyPerRedstone", 10000D).getDouble(10000D);
 		Mekanism.ATOMICDISASSEM_ENERGY_USAGE = Mekanism.configuration.get(Configuration.CATEGORY_GENERAL, "AtomicDisassemblerEnergyUsage", 10).getInt(10);
+		Mekanism.maxSpeedUpgrades = Mekanism.configuration.get(Configuration.CATEGORY_GENERAL, "maxSpeedUpgrades", 8).getInt();
+		Mekanism.maxEnergyUpgrades = Mekanism.configuration.get(Configuration.CATEGORY_GENERAL, "maxEnergyUpgrades", 8).getInt();
 		Mekanism.VOICE_PORT = Mekanism.configuration.get(Configuration.CATEGORY_GENERAL, "VoicePort", 36123, null, 1, 65535).getInt();
 		//If this is less than 1, upgrades make machines worse. If less than 0, I don't even know.
 		Mekanism.maxUpgradeMultiplier = Mekanism.configuration.get(Configuration.CATEGORY_GENERAL, "UpgradeModifier", 10, null, 1, Integer.MAX_VALUE).getInt();

--- a/src/main/java/mekanism/common/Mekanism.java
+++ b/src/main/java/mekanism/common/Mekanism.java
@@ -332,6 +332,8 @@ public class Mekanism
 	public static double FROM_UE = 1/TO_UE;
 	public static int ETHENE_BURN_TIME = 40;
 	public static int ATOMICDISASSEM_ENERGY_USAGE = 10;
+	public static int maxEnergyUpgrades = 8;
+	public static int maxSpeedUpgrades = 8;
 
 	public static boolean blacklistBC;
 	public static boolean blacklistIC2;
@@ -957,8 +959,8 @@ public class Mekanism
 		CompressedObsidian = new ItemMekanism().setUnlocalizedName("CompressedObsidian");
 		TeleportationCore = new ItemMekanism().setUnlocalizedName("TeleportationCore");
 		ElectrolyticCore = new ItemMekanism().setUnlocalizedName("ElectrolyticCore");
-		SpeedUpgrade = new ItemMachineUpgrade().setUnlocalizedName("SpeedUpgrade");
-		EnergyUpgrade = new ItemMachineUpgrade().setUnlocalizedName("EnergyUpgrade");
+		SpeedUpgrade = new ItemMachineUpgrade().setUnlocalizedName("SpeedUpgrade").setMaxStackSize(maxSpeedUpgrades);
+		EnergyUpgrade = new ItemMachineUpgrade().setUnlocalizedName("EnergyUpgrade").setMaxStackSize(maxEnergyUpgrades);
 		EnergyTablet = (ItemEnergized)new ItemEnergized(1000000).setUnlocalizedName("EnergyTablet");
 		Dictionary = new ItemDictionary().setUnlocalizedName("Dictionary");
 		FilterCard = new ItemFilterCard().setUnlocalizedName("FilterCard");

--- a/src/main/java/mekanism/common/item/ItemMachineUpgrade.java
+++ b/src/main/java/mekanism/common/item/ItemMachineUpgrade.java
@@ -7,7 +7,6 @@ public class ItemMachineUpgrade extends ItemMekanism
 	public ItemMachineUpgrade()
 	{
 		super();
-		setMaxStackSize(8);
 		setCreativeTab(Mekanism.tabMekanism);
 	}
 }

--- a/src/main/java/mekanism/common/network/PacketConfigSync.java
+++ b/src/main/java/mekanism/common/network/PacketConfigSync.java
@@ -46,6 +46,8 @@ public class PacketConfigSync implements IMessageHandler<ConfigSyncMessage, IMes
 			dataStream.writeInt(Mekanism.ATOMICDISASSEM_ENERGY_USAGE);
 			dataStream.writeInt(Mekanism.VOICE_PORT);
 			dataStream.writeInt(Mekanism.maxUpgradeMultiplier);
+			dataStream.writeInt(Mekanism.maxSpeedUpgrades);
+			dataStream.writeInt(Mekanism.maxEnergyUpgrades);
 			dataStream.writeInt(Mekanism.activeType.ordinal());
 	
 			dataStream.writeDouble(Mekanism.enrichmentChamberUsage);
@@ -102,6 +104,8 @@ public class PacketConfigSync implements IMessageHandler<ConfigSyncMessage, IMes
 			Mekanism.ATOMICDISASSEM_ENERGY_USAGE = dataStream.readInt();
 			Mekanism.VOICE_PORT = dataStream.readInt();
 			Mekanism.maxUpgradeMultiplier = dataStream.readInt();
+			Mekanism.maxSpeedUpgrades = dataStream.readInt();
+			Mekanism.maxEnergyUpgrades = dataStream.readInt();
 			Mekanism.activeType = EnergyType.values()[dataStream.readInt()];
 	
 			Mekanism.enrichmentChamberUsage = dataStream.readDouble();

--- a/src/main/java/mekanism/common/tile/component/TileComponentUpgrade.java
+++ b/src/main/java/mekanism/common/tile/component/TileComponentUpgrade.java
@@ -46,7 +46,7 @@ public class TileComponentUpgrade implements ITileComponent
 		{
 			if(tileEntity.inventory[upgradeSlot] != null)
 			{
-				if(tileEntity.inventory[upgradeSlot].isItemEqual(new ItemStack(Mekanism.EnergyUpgrade)) && energyMultiplier < 8)
+				if(tileEntity.inventory[upgradeSlot].isItemEqual(new ItemStack(Mekanism.EnergyUpgrade)) && energyMultiplier < Mekanism.maxEnergyUpgrades)
 				{
 					if(upgradeTicks < UPGRADE_TICKS_REQUIRED)
 					{
@@ -67,7 +67,7 @@ public class TileComponentUpgrade implements ITileComponent
 						tileEntity.markDirty();
 					}
 				}
-				else if(tileEntity.inventory[upgradeSlot].isItemEqual(new ItemStack(Mekanism.SpeedUpgrade)) && speedMultiplier < 8)
+				else if(tileEntity.inventory[upgradeSlot].isItemEqual(new ItemStack(Mekanism.SpeedUpgrade)) && speedMultiplier < Mekanism.maxSpeedUpgrades)
 				{
 					if(upgradeTicks < UPGRADE_TICKS_REQUIRED)
 					{


### PR DESCRIPTION
Allows setting how many upgrades should go into a machine. Works for <8
and >8 equally well. Also adjusts new max stacksize of Upgrades
depending on how many allowed in machines.