### PR TITLE
Added a nullary constructor to AdvancedMachineInput

### DIFF
--- a/src/main/java/mekanism/common/recipe/inputs/AdvancedMachineInput.java
+++ b/src/main/java/mekanism/common/recipe/inputs/AdvancedMachineInput.java
@@ -12,6 +12,10 @@ public class AdvancedMachineInput extends MachineInput<AdvancedMachineInput>
 
 	public Gas gasType;
 
+	public AdvancedMachineInput()
+	{
+	}
+
 	public AdvancedMachineInput(ItemStack item, Gas gas)
 	{
 		itemStack = item;


### PR DESCRIPTION
On line 587 of https://github.com/aidancbrady/Mekanism/blob/development/src/main/java/mekanism/common/recipe/RecipeHandler.java

Class.newInstance() can only be called by classes that contain an accessible constructor that takes no arguments, throwing an exception otherwise.