### PR TITLE
Ignores Minecraft Forge files in .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ MDK.zip
 *.classpath
 *.project
 /.settings
+/eclipse
+gradlew
+*.txt
 
 *.mtl
 *.blend1


### PR DESCRIPTION
This ignores Minecraft Forge files in .gitignore. 

I found this annoying that i had to remove and re-add Forge to prevent that the Minecraft Forge files was commited.