### PR TITLE
Added CodeChickenCore as dependency for development enviroments.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     compile "codechicken:CodeChickenLib:${config.minecraft_version}-${config.CCLIB_version}:dev"
     compile "codechicken:ForgeMultipart:${config.minecraft_version}-${config.FMP_version}:dev"
     compile "codechicken:NotEnoughItems:${config.minecraft_version}-${config.NEI_version}:dev"
+	compile "codechicken:CodeChickenCore:${config.minecraft_version}-${config.CCC_version}:dev"
 }
 
 version = "${config.minecraft_version}-${config.mod_version}." + (System.env.BUILD_NUMBER ?: "homebaked")

--- a/build.properties
+++ b/build.properties
@@ -3,4 +3,5 @@ forge_version=10.13.2.1291
 FMP_version=1.1.1.320
 CCLIB_version=1.1.1.110
 NEI_version=1.0.4.83
+CCC_version=1.0.4.35
 mod_version=8.0.0


### PR DESCRIPTION
Fixed CodeChickenCore missing, unable to run in development envitoments without it.

I think this should not affect regular Mekanism builds, but think someone should look over and verify this.