### PR TITLE
Fix Metallurgic Infuser not auto-ejecting output

### DIFF
--- a/src/main/java/mekanism/common/tile/TileEntityMetallurgicInfuser.java
+++ b/src/main/java/mekanism/common/tile/TileEntityMetallurgicInfuser.java
@@ -104,7 +104,7 @@ public class TileEntityMetallurgicInfuser extends TileEntityNoisyElectricBlock i
 		inventory = new ItemStack[5];
 		
 		upgradeComponent = new TileComponentUpgrade(this, 3);
-		ejectorComponent = new TileComponentEjector(this, configComponent.getOutputs(TransmissionType.ITEM).get(4));
+		ejectorComponent = new TileComponentEjector(this, configComponent.getOutputs(TransmissionType.ITEM).get(3));
 	}
 
 	@Override


### PR DESCRIPTION
Fixes #2268

(it was trying to auto-eject energy cells :P)

I checked all of the other TileComponentEjector instances for similar errors, the rest of them look okay.