### PR TITLE
Chemical Infuser is now improved by Speed upgrades.

### DIFF
--- a/src/main/java/mekanism/common/recipe/inputs/ChemicalPairInput.java
+++ b/src/main/java/mekanism/common/recipe/inputs/ChemicalPairInput.java
@@ -36,23 +36,30 @@ public class ChemicalPairInput extends MachineInput<ChemicalPairInput>
 	}
 	
 	public ChemicalPairInput() {}
-
-	public boolean useGas(GasTank leftTank, GasTank rightTank, boolean deplete)
-	{
+	
+	public boolean useGas(GasTank leftTank, GasTank rightTank, boolean deplete) {
+		return useGas(leftTank, rightTank, deplete, 1);
+	}
+	
+	public boolean useGas(GasTank leftTank, GasTank rightTank, boolean deplete, int scale)
+	{	
+		int leftAmount = leftGas.amount * scale;
+		int rightAmount = rightGas.amount * scale;
+		
 		if(leftTank.canDraw(leftGas.getGas()) && rightTank.canDraw(rightGas.getGas()))
 		{
-			if(leftTank.getStored() >= leftGas.amount && rightTank.getStored() >= rightGas.amount)
+			if(leftTank.getStored() >= leftAmount && rightTank.getStored() >= rightAmount)
 			{
-				leftTank.draw(leftGas.amount, deplete);
-				rightTank.draw(rightGas.amount, deplete);
+				leftTank.draw(leftAmount, deplete);
+				rightTank.draw(rightAmount, deplete);
 				return true;
 			}
 		} else if(leftTank.canDraw(rightGas.getGas()) && rightTank.canDraw(leftGas.getGas()))
 		{
-			if(leftTank.getStored() >= rightGas.amount && rightTank.getStored() >= leftGas.amount)
+			if(leftTank.getStored() >= rightAmount && rightTank.getStored() >= leftAmount)
 			{
-				leftTank.draw(rightGas.amount, deplete);
-				rightTank.draw(leftGas.amount, deplete);
+				leftTank.draw(rightAmount, deplete);
+				rightTank.draw(leftAmount, deplete);
 				return true;
 			}
 		}

--- a/src/main/java/mekanism/common/recipe/machines/ChemicalInfuserRecipe.java
+++ b/src/main/java/mekanism/common/recipe/machines/ChemicalInfuserRecipe.java
@@ -26,12 +26,13 @@ public class ChemicalInfuserRecipe extends MachineRecipe<ChemicalPairInput, GasO
 	{
 		return getInput().useGas(leftTank, rightTank, false) && getOutput().applyOutputs(outputTank, false, 1);
 	}
-
-	public void operate(GasTank leftInput, GasTank rightInput, GasTank outputTank)
+	
+	public void operate(GasTank leftInput, GasTank rightInput, GasTank outputTank, int scale)
 	{
-		if(getInput().useGas(leftInput, rightInput, true))
+		if(getInput().useGas(leftInput, rightInput, true, scale))
 		{
-			getOutput().applyOutputs(outputTank, true, 1);
+			getOutput().applyOutputs(outputTank, true, scale);
 		}
 	}
+	
 }

--- a/src/main/java/mekanism/common/tile/TileEntityChemicalInfuser.java
+++ b/src/main/java/mekanism/common/tile/TileEntityChemicalInfuser.java
@@ -124,9 +124,9 @@ public class TileEntityChemicalInfuser extends TileEntityNoisyElectricBlock impl
 			if(canOperate(recipe) && getEnergy() >= energyPerTick && MekanismUtils.canFunction(this))
 			{
 				setActive(true);
-				setEnergy(getEnergy() - energyPerTick);
 
-				operate(recipe);
+				int operations = operate(recipe);
+				setEnergy(getEnergy() - energyPerTick * operations);
 			}
 			else {
 				if(prevEnergy >= getEnergy())
@@ -196,11 +196,15 @@ public class TileEntityChemicalInfuser extends TileEntityNoisyElectricBlock impl
 		return recipe != null && recipe.canOperate(leftTank, rightTank, centerTank);
 	}
 
-	public void operate(ChemicalInfuserRecipe recipe)
+	public int operate(ChemicalInfuserRecipe recipe)
 	{
-		recipe.operate(leftTank, rightTank, centerTank);
+		int operations = getUpgradedUsage(recipe);
+		
+		recipe.operate(leftTank, rightTank, centerTank, operations);
 
 		markDirty();
+		
+		return operations;
 	}
 
 	@Override


### PR DESCRIPTION
Uses the same logic as Electrolytic Separator, adding a `scale` option to the Infuser's recipes and calling `getUpgradedUsage` to find out how many operations to do.

Fixes #2263