### PR TITLE
Fixed OreDictionary filter in Miner not writing "requireStack" to NBT.

### DIFF
--- a/src/main/java/mekanism/common/content/miner/MOreDictFilter.java
+++ b/src/main/java/mekanism/common/content/miner/MOreDictFilter.java
@@ -29,6 +29,8 @@ public class MOreDictFilter extends MinerFilter
 	@Override
 	public NBTTagCompound write(NBTTagCompound nbtTags)
 	{
+		super.write(nbtTags);
+		
 		nbtTags.setInteger("type", 1);
 		nbtTags.setString("oreDictName", oreDictName);
 


### PR DESCRIPTION
Fixed OreDictionary filter in Miner not writing "requireStack" to NBT.

This solves issue #2330.