### PR TITLE
Fixed Mekanism API

### DIFF
--- a/src/main/java/mekanism/api/ItemRetriever.java
+++ b/src/main/java/mekanism/api/ItemRetriever.java
@@ -1,6 +1,5 @@
 package mekanism.api;
 
-import mekanism.common.Mekanism;
 import net.minecraft.block.Block;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;


### PR DESCRIPTION
There was this unnecessary import that broke the latest MDK.