### PR TITLE
Development

### DIFF
--- a/src/main/resources/assets/mekanism/lang/en_US.lang
+++ b/src/main/resources/assets/mekanism/lang/en_US.lang
@@ -246,7 +246,7 @@ item.dirtySilverDust.name=Dirty Silver Dust
 item.dirtyLeadDust.name=Dirty Lead Dust
 
 //Ingots
-item.obsidianIngot.name=Obsidian Ingot
+item.obsidianIngot.name=Refined Obsidian Ingot
 item.osmiumIngot.name=Osmium Ingot
 item.bronzeIngot.name=Bronze Ingot
 item.glowstoneIngot.name=Glowstone Ingot


### PR DESCRIPTION
Changed name of "Obsidian Ingot" to "Refined Obsidian Ingot" to avoid confusion with obsidian ingots for other mods (for example Tinker's Construct)