### PR TITLE
Fixing NPE from EnergyAcceptorWrapper.java not handling ticks

### DIFF
--- a/src/main/java/mekanism/common/base/EnergyAcceptorWrapper.java
+++ b/src/main/java/mekanism/common/base/EnergyAcceptorWrapper.java
@@ -18,7 +18,7 @@ public abstract class EnergyAcceptorWrapper implements IStrictEnergyAcceptor
 
 	public static EnergyAcceptorWrapper get(TileEntity tileEntity)
 	{
-		if(tileEntity.getWorldObj() == null)
+		if(tileEntity != null && tileEntity.getWorldObj() == null)
 		{
 			return null;
 		}


### PR DESCRIPTION
Code was incorrectly handling non-TileEntity possibilities thus causing an NPE. NPE is now fixed as the system now does not return a null value as easily.