### PR TITLE
Remove hard dep on unnecessarily new forge version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ sourceCompatibility = '1.7'
 targetCompatibility = '1.7'
 
 minecraft {
-    version = config.minecraft_version + "-" + config.forge_version + "-" + config.forge_mc_version
+    version = config.minecraft_version + "-" + config.forge_version
 }
 
 processResources

--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,5 @@
 minecraft_version=1.7.10
-forge_mc_version=1710ls
-forge_version=10.13.3.1395
+forge_version=10.13.2.1291
 FMP_version=1.1.2.331
 CCLIB_version=1.1.3.136
 NEI_version=1.0.4.101

--- a/src/api/java/buildcraft/api/core/StackKey.java
+++ b/src/api/java/buildcraft/api/core/StackKey.java
@@ -87,7 +87,7 @@ public final class StackKey {
 			}
 		}
 		if (fluidStack != null) {
-			if (fluidStack.getFluidID() != k.fluidStack.getFluidID() ||
+			if (fluidStack.fluidID != k.fluidStack.fluidID ||
 					fluidStack.amount != k.fluidStack.amount ||
 					!objectsEqual(fluidStack.tag, k.fluidStack.tag)) {
 				return false;
@@ -106,7 +106,7 @@ public final class StackKey {
 		}
 		result = 31 * result + 7;
 		if (fluidStack != null) {
-			result = 31 * result + fluidStack.getFluidID();
+			result = 31 * result + fluidStack.fluidID;
 			result = 31 * result + fluidStack.amount;
 			result = 31 * result + objectHashCode(fluidStack.tag);
 		}

--- a/src/main/java/mekanism/common/FluidNetwork.java
+++ b/src/main/java/mekanism/common/FluidNetwork.java
@@ -165,7 +165,7 @@ public class FluidNetwork extends DynamicNetwork<IFluidHandler, FluidNetwork>
 
 					if(acceptor != null && fluidToSend != null)
 					{
-						fluidSent += acceptor.fill(side, new FluidStack(fluidToSend.getFluidID(), currentSending), doTransfer);
+						fluidSent += acceptor.fill(side, new FluidStack(fluidToSend.fluidID, currentSending), doTransfer);
 					}
 
 					if(fluidSent > prev)

--- a/src/main/java/mekanism/common/content/boiler/BoilerTank.java
+++ b/src/main/java/mekanism/common/content/boiler/BoilerTank.java
@@ -31,12 +31,12 @@ public abstract class BoilerTank implements IFluidTank
 	{
 		if(steamBoiler.structure != null && !steamBoiler.getWorldObj().isRemote)
 		{
-			if(resource == null || resource.getFluidID() <= 0)
+			if(resource == null || resource.fluidID <= 0)
 			{
 				return 0;
 			}
 
-			if(getFluid() == null || getFluid().getFluidID() <= 0)
+			if(getFluid() == null || getFluid().fluidID <= 0)
 			{
 				if(resource.amount <= getCapacity())
 				{
@@ -138,7 +138,7 @@ public abstract class BoilerTank implements IFluidTank
 	{
 		if(steamBoiler.structure != null && !steamBoiler.getWorldObj().isRemote)
 		{
-			if(getFluid() == null || getFluid().getFluidID() <= 0)
+			if(getFluid() == null || getFluid().fluidID <= 0)
 			{
 				return null;
 			}
@@ -160,7 +160,7 @@ public abstract class BoilerTank implements IFluidTank
 				getFluid().amount -= used;
 			}
 
-			FluidStack drained = new FluidStack(getFluid().getFluidID(), used);
+			FluidStack drained = new FluidStack(getFluid().fluidID, used);
 
 			if(getFluid().amount <= 0)
 			{

--- a/src/main/java/mekanism/common/content/tank/DynamicFluidTank.java
+++ b/src/main/java/mekanism/common/content/tank/DynamicFluidTank.java
@@ -34,7 +34,7 @@ public class DynamicFluidTank implements IFluidTank
 	{
 		if(dynamicTank.structure != null && !dynamicTank.getWorldObj().isRemote)
 		{
-			if(resource == null || resource.getFluidID() <= 0)
+			if(resource == null || resource.fluidID <= 0)
 			{
 				return 0;
 			}
@@ -44,7 +44,7 @@ public class DynamicFluidTank implements IFluidTank
 				return 0;
 			}
 
-			if(dynamicTank.structure.fluidStored == null || dynamicTank.structure.fluidStored.getFluidID() <= 0)
+			if(dynamicTank.structure.fluidStored == null || dynamicTank.structure.fluidStored.fluidID <= 0)
 			{
 				if(resource.amount <= getCapacity())
 				{
@@ -140,7 +140,7 @@ public class DynamicFluidTank implements IFluidTank
 	{
 		if(dynamicTank.structure != null && !dynamicTank.getWorldObj().isRemote)
 		{
-			if(dynamicTank.structure.fluidStored == null || dynamicTank.structure.fluidStored.getFluidID() <= 0)
+			if(dynamicTank.structure.fluidStored == null || dynamicTank.structure.fluidStored.fluidID <= 0)
 			{
 				return null;
 			}
@@ -162,7 +162,7 @@ public class DynamicFluidTank implements IFluidTank
 				dynamicTank.structure.fluidStored.amount -= used;
 			}
 
-			FluidStack drained = new FluidStack(dynamicTank.structure.fluidStored.getFluidID(), used);
+			FluidStack drained = new FluidStack(dynamicTank.structure.fluidStored.fluidID, used);
 
 			if(dynamicTank.structure.fluidStored.amount <= 0)
 			{

--- a/src/main/java/mekanism/common/item/ItemBlockMachine.java
+++ b/src/main/java/mekanism/common/item/ItemBlockMachine.java
@@ -669,7 +669,7 @@ public class ItemBlockMachine extends ItemBlock implements IEnergizedItem, ISpec
 				itemStack.setTagCompound(new NBTTagCompound());
 			}
 			
-			if(fluidStack == null || fluidStack.amount == 0 || fluidStack.getFluidID() == 0)
+			if(fluidStack == null || fluidStack.amount == 0 || fluidStack.fluidID == 0)
 			{
 				itemStack.stackTagCompound.removeTag("fluidTank");
 			}

--- a/src/main/java/mekanism/common/item/ItemGaugeDropper.java
+++ b/src/main/java/mekanism/common/item/ItemGaugeDropper.java
@@ -130,7 +130,7 @@ public class ItemGaugeDropper extends ItemMekanism implements IGasItem, IFluidCo
 			container.setTagCompound(new NBTTagCompound());
 		}
 		
-		if(stack == null || stack.amount == 0 || stack.getFluidID() == 0)
+		if(stack == null || stack.amount == 0 || stack.fluidID == 0)
 		{
 			container.stackTagCompound.removeTag("fluidStack");
 		}

--- a/src/main/java/mekanism/common/recipe/inputs/FluidInput.java
+++ b/src/main/java/mekanism/common/recipe/inputs/FluidInput.java
@@ -47,7 +47,7 @@ public class FluidInput extends MachineInput<FluidInput>
 	@Override
 	public int hashIngredients()
 	{
-		return ingredient.fluid != null ? ingredient.fluid.hashCode() : 0;
+		return ingredient.getFluid() != null ? ingredient.getFluid().hashCode() : 0;
 	}
 
 	@Override

--- a/src/main/java/mekanism/common/recipe/inputs/PressurizedInput.java
+++ b/src/main/java/mekanism/common/recipe/inputs/PressurizedInput.java
@@ -147,7 +147,7 @@ public class PressurizedInput extends MachineInput<PressurizedInput>
 	@Override
 	public int hashIngredients()
 	{
-		return StackUtils.hashItemStack(theSolid) << 16 | (theFluid.fluid != null ? theFluid.fluid.hashCode() : 0) << 8 | theGas.hashCode();
+		return StackUtils.hashItemStack(theSolid) << 16 | (theFluid.getFluid() != null ? theFluid.getFluid().hashCode() : 0) << 8 | theGas.hashCode();
 	}
 
 	@Override

--- a/src/main/java/mekanism/common/tile/TileEntityBoiler.java
+++ b/src/main/java/mekanism/common/tile/TileEntityBoiler.java
@@ -312,7 +312,7 @@ public class TileEntityBoiler extends TileEntityMultiblock<SynchronizedBoilerDat
 		if(structure != null && structure.waterStored != null)
 		{
 			data.add(1);
-			data.add(structure.waterStored.getFluidID());
+			data.add(structure.waterStored.fluidID);
 			data.add(structure.waterStored.amount);
 		}
 		else {
@@ -322,7 +322,7 @@ public class TileEntityBoiler extends TileEntityMultiblock<SynchronizedBoilerDat
 		if(structure != null && structure.steamStored != null)
 		{
 			data.add(1);
-			data.add(structure.steamStored.getFluidID());
+			data.add(structure.steamStored.fluidID);
 			data.add(structure.steamStored.amount);
 		}
 		else {

--- a/src/main/java/mekanism/common/tile/TileEntityDynamicTank.java
+++ b/src/main/java/mekanism/common/tile/TileEntityDynamicTank.java
@@ -298,7 +298,7 @@ public class TileEntityDynamicTank extends TileEntityMultiblock<SynchronizedTank
 			if(structure.fluidStored != null)
 			{
 				data.add(1);
-				data.add(structure.fluidStored.getFluidID());
+				data.add(structure.fluidStored.fluidID);
 				data.add(structure.fluidStored.amount);
 			}
 			else {

--- a/src/main/java/mekanism/common/tile/TileEntityElectricPump.java
+++ b/src/main/java/mekanism/common/tile/TileEntityElectricPump.java
@@ -282,7 +282,7 @@ public class TileEntityElectricPump extends TileEntityElectricBlock implements I
 		if(fluidTank.getFluid() != null)
 		{
 			data.add(1);
-			data.add(fluidTank.getFluid().getFluidID());
+			data.add(fluidTank.getFluid().fluidID);
 			data.add(fluidTank.getFluid().amount);
 		}
 		else {

--- a/src/main/java/mekanism/common/tile/TileEntityFluidicPlenisher.java
+++ b/src/main/java/mekanism/common/tile/TileEntityFluidicPlenisher.java
@@ -285,7 +285,7 @@ public class TileEntityFluidicPlenisher extends TileEntityElectricBlock implemen
 		if(fluidTank.getFluid() != null)
 		{
 			data.add(1);
-			data.add(fluidTank.getFluid().getFluidID());
+			data.add(fluidTank.getFluid().fluidID);
 			data.add(fluidTank.getFluid().amount);
 		}
 		else {

--- a/src/main/java/mekanism/common/tile/TileEntityPortableTank.java
+++ b/src/main/java/mekanism/common/tile/TileEntityPortableTank.java
@@ -434,7 +434,7 @@ public class TileEntityPortableTank extends TileEntityContainerBlock implements 
 		if(fluidTank.getFluid() != null)
 		{
 			data.add(1);
-			data.add(fluidTank.getFluid().getFluidID());
+			data.add(fluidTank.getFluid().fluidID);
 			data.add(fluidTank.getFluid().amount);
 		}
 		else {

--- a/src/main/java/mekanism/common/tile/TileEntityRotaryCondensentrator.java
+++ b/src/main/java/mekanism/common/tile/TileEntityRotaryCondensentrator.java
@@ -414,7 +414,7 @@ public class TileEntityRotaryCondensentrator extends TileEntityElectricBlock imp
 		if(fluidTank.getFluid() != null)
 		{
 			data.add(true);
-			data.add(fluidTank.getFluid().getFluidID());
+			data.add(fluidTank.getFluid().fluidID);
 			data.add(fluidTank.getFluid().amount);
 		}
 		else {

--- a/src/main/java/mekanism/common/tile/TileEntitySolarEvaporationController.java
+++ b/src/main/java/mekanism/common/tile/TileEntitySolarEvaporationController.java
@@ -711,7 +711,7 @@ public class TileEntitySolarEvaporationController extends TileEntitySolarEvapora
 		if(inputTank.getFluid() != null)
 		{
 			data.add(true);
-			data.add(inputTank.getFluid().getFluidID());
+			data.add(inputTank.getFluid().fluidID);
 			data.add(inputTank.getFluid().amount);
 		}
 		else {
@@ -721,7 +721,7 @@ public class TileEntitySolarEvaporationController extends TileEntitySolarEvapora
 		if(outputTank.getFluid() != null)
 		{
 			data.add(true);
-			data.add(outputTank.getFluid().getFluidID());
+			data.add(outputTank.getFluid().fluidID);
 			data.add(outputTank.getFluid().amount);
 		}
 		else {

--- a/src/main/java/mekanism/generators/common/item/ItemBlockGenerator.java
+++ b/src/main/java/mekanism/generators/common/item/ItemBlockGenerator.java
@@ -271,7 +271,7 @@ public class ItemBlockGenerator extends ItemBlock implements IEnergizedItem, ISp
 	@Override
 	public void setFluidStack(FluidStack fluidStack, Object... data)
 	{
-		if(fluidStack == null || fluidStack.amount == 0 || fluidStack.getFluidID() == 0)
+		if(fluidStack == null || fluidStack.amount == 0 || fluidStack.fluidID == 0)
 		{
 			return;
 		}

--- a/src/main/java/mekanism/generators/common/tile/TileEntityHeatGenerator.java
+++ b/src/main/java/mekanism/generators/common/tile/TileEntityHeatGenerator.java
@@ -76,7 +76,7 @@ public class TileEntityHeatGenerator extends TileEntityGenerator implements IFlu
 				}
 				else if(fluid != null)
 				{
-					if(fluid != null && fluid.getFluidID() == FluidRegistry.LAVA.getID())
+					if(fluid != null && fluid.fluidID == FluidRegistry.LAVA.getID())
 					{
 						if(lavaTank.getFluid() == null || lavaTank.getFluid().amount+fluid.amount <= lavaTank.getCapacity())
 						{
@@ -152,7 +152,7 @@ public class TileEntityHeatGenerator extends TileEntityGenerator implements IFlu
 	{
 		if(slotID == 0)
 		{
-			return getFuel(itemstack) > 0 || (FluidContainerRegistry.getFluidForFilledItem(itemstack) != null && FluidContainerRegistry.getFluidForFilledItem(itemstack).getFluidID() == FluidRegistry.LAVA.getID());
+			return getFuel(itemstack) > 0 || (FluidContainerRegistry.getFluidForFilledItem(itemstack) != null && FluidContainerRegistry.getFluidForFilledItem(itemstack).fluidID == FluidRegistry.LAVA.getID());
 		}
 		else if(slotID == 1)
 		{
@@ -329,7 +329,7 @@ public class TileEntityHeatGenerator extends TileEntityGenerator implements IFlu
 	@Override
 	public int fill(ForgeDirection from, FluidStack resource, boolean doFill)
 	{
-		if(resource.getFluidID() == FluidRegistry.LAVA.getID() && from != ForgeDirection.getOrientation(facing))
+		if(resource.fluidID == FluidRegistry.LAVA.getID() && from != ForgeDirection.getOrientation(facing))
 		{
 			return lavaTank.fill(resource, doFill);
 		}


### PR DESCRIPTION
There is no need to depend on such a new version, it only frustrates users who cannot update. I have tested a custom build with this code on the very latest forge release, and everything fluid related works perfectly fine.

It will now build on Forge 1291 (the *recommended* version for users)