### PR TITLE
Make jetpack size configurable

### DIFF
--- a/src/main/java/mekanism/api/MekanismConfig.java
+++ b/src/main/java/mekanism/api/MekanismConfig.java
@@ -50,6 +50,7 @@ public class MekanismConfig
 		public static boolean prefilledPortableTanks;
 		public static double armoredJetpackDamageRatio;
 		public static int armoredJetpackDamageMax;
+		public static int jetpackTankSize;
 		public static boolean aestheticWorldDamage;
 		public static boolean opsBypassRestrictions;
 	}

--- a/src/main/java/mekanism/common/CommonProxy.java
+++ b/src/main/java/mekanism/common/CommonProxy.java
@@ -258,6 +258,7 @@ public class CommonProxy
 		general.armoredJetpackDamageRatio = Mekanism.configuration.get(Configuration.CATEGORY_GENERAL, "ArmoredJetpackDamageRatio", 0.8).getDouble();
 		general.armoredJetpackDamageMax = Mekanism.configuration.get(Configuration.CATEGORY_GENERAL, "ArmoredJepackDamageMax", 115).getInt();
 		general.aestheticWorldDamage = Mekanism.configuration.get(Configuration.CATEGORY_GENERAL, "AestheticWorldDamage", true).getBoolean();
+		general.jetpackTankSize = Mekanism.configuration.get(Configuration.CATEGORY_GENERAL, "JetpackTankSize", 24000).getInt();
 		general.opsBypassRestrictions = Mekanism.configuration.get(Configuration.CATEGORY_GENERAL, "OpsBypassRestrictions", true).getBoolean();
 		
 		general.blacklistIC2 = Mekanism.configuration.get(Configuration.CATEGORY_GENERAL, "BlacklistIC2Power", false).getBoolean();

--- a/src/main/java/mekanism/common/item/ItemJetpack.java
+++ b/src/main/java/mekanism/common/item/ItemJetpack.java
@@ -31,7 +31,6 @@ import cpw.mods.fml.relauncher.SideOnly;
 
 public class ItemJetpack extends ItemArmor implements IGasItem, ISpecialArmor
 {
-	public int MAX_GAS = 24000;
 	public int TRANSFER_RATE = 16;
 
 	public ItemJetpack()
@@ -105,7 +104,7 @@ public class ItemJetpack extends ItemArmor implements IGasItem, ISpecialArmor
 	@Override
 	public int getMaxGas(ItemStack itemstack)
 	{
-		return MAX_GAS;
+		return general.jetpackTankSize;
 	}
 
 	@Override


### PR DESCRIPTION
As a server admin, I thought the jetpack hydrogen tank was waaay too large, so I went to the config to reduce it... but there wasn't a config option!  So, I added one.

(I haven't tested this because I can't get the mod to build, but it's a really simple edit)