### PR TITLE
Alllow Mekanism machines to accept power from ForgeDirection.UNKOWN

### DIFF
--- a/src/main/java/mekanism/common/tile/TileEntityElectricBlock.java
+++ b/src/main/java/mekanism/common/tile/TileEntityElectricBlock.java
@@ -214,7 +214,7 @@ public abstract class TileEntityElectricBlock extends TileEntityContainerBlock i
 	@Method(modid = "CoFHCore")
 	public int receiveEnergy(ForgeDirection from, int maxReceive, boolean simulate)
 	{
-		if(getConsumingSides().contains(from))
+		if(getConsumingSides().contains(from) || from == ForgeDirection.UNKNOWN)
 		{
 			double toAdd = (int)Math.min(getMaxEnergy()-getEnergy(), maxReceive* general.FROM_TE);
 


### PR DESCRIPTION
ForgeDirection.UNKNOWN is used to supply power to machines remotely, including from my mod. This is a valid use of the RF api (talked extensively with skyboy about this).