### PR TITLE
Another bugfix.

### DIFF
--- a/src/main/java/mekanism/common/content/transporter/StackSearcher.java
+++ b/src/main/java/mekanism/common/content/transporter/StackSearcher.java
@@ -18,6 +18,7 @@ public class StackSearcher
 	public StackSearcher(IInventory inventory, ForgeDirection direction)
 	{
 		theInventory = InventoryUtils.checkChestInv(inventory);
+		side = direction;
 		if(!(theInventory instanceof ISidedInventory))
 		{
 			i = inventory.getSizeInventory();
@@ -30,7 +31,6 @@ public class StackSearcher
 				i = slots.length;
 			}
 		}
-		side = direction;
 	}
 
 	public InvStack takeTopStack(Finder id)


### PR DESCRIPTION
Fixes #2844.

Also, @aidancbrady you probably should release a 8.1.7 soon with the bugfixes. This is the second bug that crashes minecraft in singleplayer (bin bug was first), and will pretty much crash any server which uses logistical sorters on anything that uses sided inventories.