### PR TITLE
Fix for CC peripherals always throwing error.

### DIFF
--- a/src/main/java/mekanism/common/integration/CCPeripheral.java
+++ b/src/main/java/mekanism/common/integration/CCPeripheral.java
@@ -40,8 +40,9 @@ public class CCPeripheral implements IPeripheral
             return computerTile.invoke(method, arguments);
         } catch(NoSuchMethodException e) {
             return new Object[] {"Unknown command."};
-        } finally {
-            return new Object[] {"Error."};
+        } catch(Exception e) {
+        	e.printStackTrace();
+        	return new Object[] {"Error."};
         }
     }
 


### PR DESCRIPTION
At least under a Linux and Windows environment using Java 7 or 8 when doing a call from ComputerCraft such as:
peripheral.call("right", "getStored") on an energy cube the call would always return "Error.". This addresses that bug.