### PR TITLE
Fix, Logistical Sorter ItemStack filter is not ignoring the item damage.

### DIFF
--- a/src/main/java/mekanism/api/util/StackUtils.java
+++ b/src/main/java/mekanism/api/util/StackUtils.java
@@ -62,6 +62,15 @@ public final class StackUtils
 		return wild.getItem() == check.getItem() && (wild.getItemDamage() == OreDictionary.WILDCARD_VALUE || wild.getItemDamage() == check.getItemDamage());
 	}
 
+	public static boolean equalsIgnoreItemDamage(ItemStack wild, ItemStack check)
+	{
+		if(wild == null || check == null)
+		{
+			return check == wild;
+		}
+		return wild.getItem() == check.getItem();
+	}
+
 	public static boolean equalsWildcardWithNBT(ItemStack wild, ItemStack check)
 	{
 		return equalsWildcard(wild, check) && (wild.stackTagCompound == null ? check.stackTagCompound == null : (wild.stackTagCompound == check.stackTagCompound || wild.stackTagCompound.equals(check.stackTagCompound)));

--- a/src/main/java/mekanism/common/content/transporter/Finder.java
+++ b/src/main/java/mekanism/common/content/transporter/Finder.java
@@ -87,7 +87,7 @@ public abstract class Finder
 		@Override
 		public boolean modifies(ItemStack stack)
 		{
-			return StackUtils.equalsWildcard(itemType, stack);
+			return StackUtils.equalsIgnoreItemDamage(itemType, stack);
 		}
 	}
 	


### PR DESCRIPTION
The filter will only accept items with the same damage that was used to
make the ItemStack filter.