### PR TITLE
Peripherals api includes invalid indexes for methods with string parameters

### DIFF
--- a/src/main/java/mekanism/common/tile/TileEntityDigitalMiner.java
+++ b/src/main/java/mekanism/common/tile/TileEntityDigitalMiner.java
@@ -1243,7 +1243,7 @@ public class TileEntityDigitalMiner extends TileEntityElectricBlock implements I
 			{
 				num = ((Double)arguments[0]).intValue();
 			}
-			else if(arguments[0] instanceof String && (method != 6 && method != 7))
+			else if(arguments[0] instanceof String && (method != 5 && method != 6))
 			{
 				num = Integer.parseInt((String)arguments[0]);
 			}


### PR DESCRIPTION
The method indexes (6 and 7) correspond to "removeOreFilter" and "reset" instead of "addOreFilter" and "removeOreFilter".

Fixed the two method indexes listed to the correct ones.