### PR TITLE
Fake Player location change

### DIFF
--- a/src/main/java/mekanism/common/tile/TileEntityDigitalMiner.java
+++ b/src/main/java/mekanism/common/tile/TileEntityDigitalMiner.java
@@ -337,7 +337,7 @@ public class TileEntityDigitalMiner extends TileEntityElectricBlock implements I
 		Block block = obj.getBlock(worldObj);
 		int meta = obj.getMetadata(worldObj);
 		
-		EntityPlayer dummy = Mekanism.proxy.getDummyPlayer((WorldServer)worldObj, obj.xCoord, obj.yCoord, obj.zCoord).get();
+		EntityPlayer dummy = Mekanism.proxy.getDummyPlayer((WorldServer)worldObj, this.xCoord, this.yCoord, this.zCoord).get();
 		BlockEvent.BreakEvent event = new BlockEvent.BreakEvent(obj.xCoord, obj.yCoord, obj.zCoord, worldObj, block, meta, dummy);
 		MinecraftForge.EVENT_BUS.post(event);
 		


### PR DESCRIPTION
This PR should ensure the fake player that breaks the blocks for a digital miner actually reports its location as the digital miner, not the location of the block being broken.

See https://github.com/BuildCraft/BuildCraft/issues/3323 for more information - BuildCraft have implemented this.

@aidancbrady If this is wrong, I apologise. Pretty new to java :)