### PR TITLE
Update ClientProxy.java to use new java arrays

### DIFF
--- a/src/main/java/mekanism/client/ClientProxy.java
+++ b/src/main/java/mekanism/client/ClientProxy.java
@@ -4,6 +4,7 @@ import static mekanism.common.block.states.BlockStatePlastic.colorProperty;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -238,7 +239,6 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.network.simpleimpl.MessageContext;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
-import scala.actors.threadpool.Arrays;
 
 /**
  * Client proxy for the Mekanism mod.


### PR DESCRIPTION
scala.actors.threadpool.Arrays is depreciated in favour of java.util.Arrays.

Fixes issue: cpw.mods.fml.common.LoaderException: java.lang.NoClassDefFoundError: scala/actors/threadpool/Arrays