### PR TITLE
Update build.properties

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 minecraft_version=1.9.4
 mappings_version=snapshot_20160523
-forge_version=12.17.0.1940-1.9.4
+forge_version=12.17.0.1940
 mcmp_version=1.2.0_72
 jei_version=3.4.0.204
 mod_version=9.0.2

--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 minecraft_version=1.9.4
 mappings_version=snapshot_20160523
-forge_version=12.17.0.1909-1.9.4
+forge_version=12.17.0.1940-1.9.4
 mcmp_version=1.2.0_72
 jei_version=3.4.0.204
 mod_version=9.0.2


### PR DESCRIPTION
EnumHelper.addArmorMaterial is broken in 1909. Fixed in 1940