### PR TITLE
Digital Miner Alternate Operation

### DIFF
--- a/src/main/java/mekanism/api/MekanismConfig.java
+++ b/src/main/java/mekanism/api/MekanismConfig.java
@@ -40,6 +40,7 @@ public class MekanismConfig
 		public static double FROM_TE;
 		public static int laserRange;
 		public static double laserEnergyNeededPerHardness;
+		public static boolean minerAltOperation;
 		public static double minerSilkMultiplier = 6;
 		public static boolean blacklistIC2;
 		public static boolean blacklistRF;

--- a/src/main/java/mekanism/common/CommonProxy.java
+++ b/src/main/java/mekanism/common/CommonProxy.java
@@ -275,6 +275,7 @@ public class CommonProxy implements IGuiProvider
 		general.VOICE_PORT = Mekanism.configuration.get(Configuration.CATEGORY_GENERAL, "VoicePort", 36123, null, 1, 65535).getInt();
 		//If this is less than 1, upgrades make machines worse. If less than 0, I don't even know.
 		general.maxUpgradeMultiplier = Mekanism.configuration.get(Configuration.CATEGORY_GENERAL, "UpgradeModifier", 10, null, 1, Integer.MAX_VALUE).getInt();
+		general.minerAltOperation = Mekanism.configuration.get(Configuration.CATEGORY_GENERAL, "MinerAltOperation", true).getBoolean();
 		general.minerSilkMultiplier = Mekanism.configuration.get(Configuration.CATEGORY_GENERAL, "MinerSilkMultiplier", 6).getDouble();
 		general.prefilledFluidTanks = Mekanism.configuration.get(Configuration.CATEGORY_GENERAL, "PrefilledFluidTanks", true).getBoolean();
 		general.prefilledGasTanks = Mekanism.configuration.get(Configuration.CATEGORY_GENERAL, "PrefilledGasTanks", true).getBoolean();

--- a/src/main/java/mekanism/common/tile/TileEntityDigitalMiner.java
+++ b/src/main/java/mekanism/common/tile/TileEntityDigitalMiner.java
@@ -1,7 +1,5 @@
 package mekanism.common.tile;
 
-import io.netty.buffer.ByteBuf;
-
 import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.EnumSet;
@@ -12,8 +10,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import io.netty.buffer.ByteBuf;
 import mekanism.api.Chunk3D;
 import mekanism.api.Coord4D;
+import mekanism.api.MekanismConfig.general;
 import mekanism.api.MekanismConfig.usage;
 import mekanism.api.Range4D;
 import mekanism.common.HashList;
@@ -58,8 +60,6 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.util.Constants.NBT;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.event.world.BlockEvent;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 
 public class TileEntityDigitalMiner extends TileEntityElectricBlock implements IUpgradeTile, IRedstoneControl, IActiveState, ISustainedData, IAdvancedBoundingBlock
 {
@@ -211,7 +211,7 @@ public class TileEntityDigitalMiner extends TileEntityElectricBlock implements I
 						{
 							int index = set.nextSetBit(next);
 							Coord4D coord = getCoordFromIndex(index);
-	
+
 							if(index == -1)
 							{
 								toRemove.add(chunk);
@@ -1044,7 +1044,11 @@ public class TileEntityDigitalMiner extends TileEntityElectricBlock implements I
 
 	public int getTotalSize()
 	{
-		return getDiameter()*getDiameter()*(maxY-minY+1);
+		// Get total size based on operation type
+		if( general.minerAltOperation )
+			return getDiameter()*getDiameter()*(yCoord+radius+1);
+		else
+			return getDiameter()*getDiameter()*(maxY-minY+1);
 	}
 
 	public int getDiameter()
@@ -1054,17 +1058,21 @@ public class TileEntityDigitalMiner extends TileEntityElectricBlock implements I
 
 	public Coord4D getStartingCoord()
 	{
-		return new Coord4D(xCoord-radius, minY, zCoord-radius, worldObj.provider.dimensionId);
+		// Get stating coordinates based on operation type
+		if( general.minerAltOperation )
+			return new Coord4D(xCoord-radius, yCoord+radius, zCoord-radius, worldObj.provider.dimensionId);
+		else
+			return new Coord4D(xCoord-radius, minY, zCoord-radius, worldObj.provider.dimensionId);
 	}
 
 	public Coord4D getCoordFromIndex(int index)
 	{
 		int diameter = getDiameter();
 		Coord4D start = getStartingCoord();
-
+		
 		int x = start.xCoord+index%diameter;
 		int z = start.zCoord+(index/diameter)%diameter;
-		int y = start.yCoord+(index/diameter/diameter);
+		int y = general.minerAltOperation ? start.yCoord-(index/diameter/diameter) : start.yCoord+(index/diameter/diameter);
 
 		return new Coord4D(x, y, z, worldObj.provider.dimensionId);
 	}

--- a/src/main/java/mekanism/common/tile/TileEntityDigitalMiner.java
+++ b/src/main/java/mekanism/common/tile/TileEntityDigitalMiner.java
@@ -126,6 +126,31 @@ public class TileEntityDigitalMiner extends TileEntityElectricBlock implements I
 		radius = 10;
 	}
 
+	// *------*
+	// Support functions for alternative miner operations
+	private boolean isInsideSphere( int x, int y, int z, int radius )
+	{
+		return Math.pow( x, 2 ) + Math.pow( y, 2 ) + Math.pow( z, 2 ) - Math.pow( radius, 2 ) <= 0;
+	}
+	
+	private boolean isSurface( int x, int y, int z, int radius )
+	{
+		int setCount = 0;
+		int unsetCount = 0;
+		
+		if( isInsideSphere( x+1, y, z, radius) ) setCount++; else unsetCount++;
+		if( isInsideSphere( x-1, y, z, radius) ) setCount++; else unsetCount++;
+
+		if( isInsideSphere( x, y+1, z, radius) ) setCount++; else unsetCount++;
+		if( isInsideSphere( x, y-1, z, radius) ) setCount++; else unsetCount++;
+
+		if( isInsideSphere( x, y, z+1, radius) ) setCount++; else unsetCount++;
+		if( isInsideSphere( x, y, z-1, radius) ) setCount++; else unsetCount++;
+
+		return setCount > 0 && unsetCount > 0;
+	}
+	// *------*
+
 	@Override
 	public void onUpdate()
 	{


### PR DESCRIPTION
This offers an alternative operating boundary shape to the digital miner. The change makes the miner start with a dome above the miner with the size determined by the radius setting, then continues with a cylinder down to the bottom of the map. This can be seen through the visualizer. Also with this, the max/min y setting is ignores. These changes can be turned on or off through the "MinerAltOperation" config option.