### PR TITLE
Fixed rare NPC spawning glitch

### DIFF
--- a/src/main/java/mekanism/common/block/BlockBasic.java
+++ b/src/main/java/mekanism/common/block/BlockBasic.java
@@ -370,23 +370,28 @@ public abstract class BlockBasic extends Block implements ICTMBlock
 					case 2:
 					case 7:
 					case 8:
-						TileEntityMultiblock tileEntity = (TileEntityMultiblock)world.getTileEntity(pos);
-
-						if(tileEntity != null)
-						{
-							if(FMLCommonHandler.instance().getEffectiveSide() == Side.SERVER)
+						try {
+							TileEntityMultiblock tileEntity = (TileEntityMultiblock)world.getTileEntity(pos);
+	
+							if(tileEntity != null)
 							{
-								if(tileEntity.structure != null)
+								if(FMLCommonHandler.instance().getEffectiveSide() == Side.SERVER)
 								{
-									return false;
-								}
-							} 
-							else {
-								if(tileEntity.clientHasStructure)
-								{
-									return false;
+									if(tileEntity.structure != null)
+									{
+										return false;
+									}
+								} 
+								else {
+									if(tileEntity.clientHasStructure)
+									{
+										return false;
+									}
 								}
 							}
+						} catch(ClassCastException cce) {
+							System.err.println("Creature attempted to spawn in an invalid location");
+							return false;
 						}
 					default:
 						return super.canCreatureSpawn(state, world, pos, type);


### PR DESCRIPTION
This should fix issue #3663, which occurred when a creature tries to spawn on a Solar Evaporation block and the block is casted to a type it isn't. 
