### PR TITLE
Re-implements https://github.com/aidancbrady/Mekanism/pull/3209

### DIFF
--- a/src/main/java/mekanism/common/tile/TileEntityDigitalMiner.java
+++ b/src/main/java/mekanism/common/tile/TileEntityDigitalMiner.java
@@ -365,7 +365,7 @@ public class TileEntityDigitalMiner extends TileEntityElectricBlock implements I
 		IBlockState state = obj.getBlockState(worldObj);
 		Block block = state.getBlock();
 		
-		EntityPlayer dummy = Mekanism.proxy.getDummyPlayer((WorldServer)worldObj, obj.xCoord, obj.yCoord, obj.zCoord).get();
+		EntityPlayer dummy = Mekanism.proxy.getDummyPlayer((WorldServer)worldObj, this.xCoord, this.yCoord, this.zCoord).get();
 		BlockEvent.BreakEvent event = new BlockEvent.BreakEvent(worldObj, obj.getPos(), state, dummy);
 		MinecraftForge.EVENT_BUS.post(event);
 		


### PR DESCRIPTION
This was added previously, I believe, but then never put into Mekanism v9.1

Note, if you no longer support v1.7.10 then nevermind..... I will create a custom build for this and share it - because this only benefits Cauldron/Thermos users which use Bukkit based protections (Factions, Towny, WorldGuard etc).

We implemented the latest Mek and BC and the tweak to allow this the machines to behave, found BC working (and after some checking) I realised Mek doesn't have the fix :(