### PR TITLE
More dynamic tank network optimization

### DIFF
--- a/src/main/java/mekanism/common/content/tank/SynchronizedTankData.java
+++ b/src/main/java/mekanism/common/content/tank/SynchronizedTankData.java
@@ -16,6 +16,7 @@ public class SynchronizedTankData extends SynchronizedData<SynchronizedTankData>
 	
 	/** For use by rendering segment */
 	public FluidStack prevFluid;
+	public int prevFluidStage = 0;
 	
 	public ContainerEditMode editMode = ContainerEditMode.BOTH;
 
@@ -32,7 +33,11 @@ public class SynchronizedTankData extends SynchronizedData<SynchronizedTankData>
 		
 		if(fluidStored != null && prevFluid != null)
 		{
-			if((fluidStored.getFluid() != prevFluid.getFluid()) || (fluidStored.amount != prevFluid.amount))
+			int totalStage 		= (volHeight - 2) * (TankUpdateProtocol.FLUID_PER_TANK / 100);
+			int currentStage 	= (int)((fluidStored.amount / (float)(volume*TankUpdateProtocol.FLUID_PER_TANK)) * totalStage);
+			boolean stageChanged 	= currentStage != prevFluidStage;
+			prevFluidStage 		= currentStage;
+			if((fluidStored.getFluid() != prevFluid.getFluid()) || stageChanged)
 			{
 				return true;
 			}


### PR DESCRIPTION
Currently, the dynamic tank will send update packet if stored fluid amount is changed even if the changed amount is very little and has no visual change(10000000->9999990) and wasting the server bandwidth. 
Instead of send change every time fluid amount changed. This edit will only send update packet when fluid level is noticeably changed saving a lot of bandwidth usage if the tank is actively getting filled and drained every tick.
