### PR TITLE
Account for meta in the JEI ISubtypeInterpreter

### DIFF
--- a/src/main/java/mekanism/client/jei/MekanismJEI.java
+++ b/src/main/java/mekanism/client/jei/MekanismJEI.java
@@ -122,16 +122,16 @@ public class MekanismJEI implements IModPlugin
 		@Override
 		public String getSubtypeInfo(ItemStack itemStack) 
 		{
-			String ret = "";
+			String ret = Integer.toString(itemStack.getMetadata());
 			
 			if(itemStack.getItem() instanceof ITierItem)
 			{
-				ret += ((ITierItem)itemStack.getItem()).getBaseTier(itemStack).getSimpleName();
+				ret += ":" + ((ITierItem)itemStack.getItem()).getBaseTier(itemStack).getSimpleName();
 			}
 			
 			if(itemStack.getItem() instanceof IFactory)
 			{
-				ret += RecipeType.values()[((IFactory)itemStack.getItem()).getRecipeType(itemStack)].getName();
+				ret += ":" + RecipeType.values()[((IFactory)itemStack.getItem()).getRecipeType(itemStack)].getName();
 			}
 			
 			return ret.isEmpty() ? null : ret.toLowerCase();


### PR DESCRIPTION
I think an old JEI was using meta + the `ISubtypeInterpreter`, but it was not intended, and JEI does not do that now.
Right now, if you look up Mekanism stuff in JEI it shows all kinds of blocks instead of just the intended block.
This PR fixes the Mekanism `ISubtypeInterpreter` so that it differentiates machines and basic blocks again.
