### PR TITLE
Fix for issue #3954

### DIFF
--- a/src/main/java/mekanism/common/block/BlockPlastic.java
+++ b/src/main/java/mekanism/common/block/BlockPlastic.java
@@ -55,7 +55,7 @@ public class BlockPlastic extends Block
 	@Override
 	public int getMetaFromState(IBlockState state)
 	{
-		return state.getValue(BlockStatePlastic.colorProperty).getMetadata();
+		return state.getValue(BlockStatePlastic.colorProperty).getDyeDamage();
 	}
 
 	@Override


### PR DESCRIPTION
Breaking plastic blocks drops wrong colour. Also WAILA & TOP rendered the wrong color in the overlay.
With this fix, both are working as supposed.

Fix for #3954 