### PR TITLE
Bin IItemHandler

### DIFF
--- a/src/main/java/mekanism/common/tile/TileEntityBin.java
+++ b/src/main/java/mekanism/common/tile/TileEntityBin.java
@@ -142,11 +142,11 @@ public class TileEntityBin extends TileEntityBasicBlock implements ISidedInvento
 		return true;
 	}
 
-	public ItemStack add(ItemStack stack)
+	public ItemStack add(ItemStack stack, boolean simulate)
 	{
 		if(isValid(stack) && (tier == BinTier.CREATIVE || getItemCount() != tier.storage))
 		{
-			if(itemType == null)
+			if(itemType == null && !simulate)
 			{
 				setItemType(stack);
 			}
@@ -155,24 +155,38 @@ public class TileEntityBin extends TileEntityBasicBlock implements ISidedInvento
 			{
 				if(getItemCount() + stack.stackSize <= tier.storage)
 				{
-					setItemCount(getItemCount() + stack.stackSize);
+					if (!simulate)
+					{
+						setItemCount(getItemCount() + stack.stackSize);
+					}
 					return null;
 				}
 				else {
-					ItemStack rejects = itemType.copy();
+					ItemStack rejects = stack.copy();
 					rejects.stackSize = (getItemCount()+stack.stackSize) - tier.storage;
-	
-					setItemCount(tier.storage);
+
+					if (!simulate)
+					{
+						setItemCount(tier.storage);
+					}
 	
 					return rejects;
 				}
 			}
 			else {
-				setItemCount(Integer.MAX_VALUE);
+				if (!simulate)
+				{
+					setItemCount(Integer.MAX_VALUE);
+				}
 			}
 		}
 
 		return stack;
+	}
+
+	public ItemStack add(ItemStack stack)
+	{
+		return add(stack, false);
 	}
 
 	public ItemStack removeStack()
@@ -185,7 +199,7 @@ public class TileEntityBin extends TileEntityBasicBlock implements ISidedInvento
 		return remove(bottomStack.stackSize);
 	}
 
-	public ItemStack remove(int amount)
+	public ItemStack remove(int amount, boolean simulate)
 	{
 		if(getItemCount() == 0)
 		{
@@ -195,12 +209,17 @@ public class TileEntityBin extends TileEntityBasicBlock implements ISidedInvento
 		ItemStack ret = itemType.copy();
 		ret.stackSize = Math.min(Math.min(amount, itemType.getMaxStackSize()), getItemCount());
 		
-		if(tier != BinTier.CREATIVE)
+		if(tier != BinTier.CREATIVE && !simulate)
 		{
 			setItemCount(getItemCount() - ret.stackSize);
 		}
 
 		return ret;
+	}
+
+	public ItemStack remove(int amount)
+	{
+		return remove(amount, false);
 	}
 
 	public int getItemCount()

--- a/src/main/java/mekanism/common/tile/TileEntityBin.java
+++ b/src/main/java/mekanism/common/tile/TileEntityBin.java
@@ -39,6 +39,8 @@ import net.minecraft.util.text.TextComponentString;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.fml.common.FMLCommonHandler;
 import net.minecraftforge.fml.common.Optional.Interface;
+import net.minecraftforge.items.IItemHandler;
+import net.minecraftforge.items.CapabilityItemHandler;
 import powercrystals.minefactoryreloaded.api.IDeepStorageUnit;
 
 @Interface(iface = "powercrystals.minefactoryreloaded.api.IDeepStorageUnit", modid = "MineFactoryReloaded")
@@ -66,6 +68,12 @@ public class TileEntityBin extends TileEntityBasicBlock implements ISidedInvento
 	public int prevCount;
 
 	public int clientAmount;
+
+	private BinItemHandler myItemHandler;
+
+	public TileEntityBin(){
+		this.myItemHandler = new BinItemHandler(this);
+	}
 	
 	@Override
 	public boolean upgrade(BaseTier upgradeTier)
@@ -673,7 +681,7 @@ public class TileEntityBin extends TileEntityBasicBlock implements ISidedInvento
 	@Override
 	public boolean hasCapability(Capability<?> capability, EnumFacing side)
 	{
-		return capability == Capabilities.CONFIGURABLE_CAPABILITY || super.hasCapability(capability, side);
+		return capability == Capabilities.CONFIGURABLE_CAPABILITY || capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY || super.hasCapability(capability, side);
 	}
 
 	@Override
@@ -683,7 +691,53 @@ public class TileEntityBin extends TileEntityBasicBlock implements ISidedInvento
 		{
 			return (T)this;
 		}
+		else if(capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY)
+		{
+			return (T)myItemHandler;
+		}
 		
 		return super.getCapability(capability, side);
+	}
+
+	private class BinItemHandler implements IItemHandler
+	{
+		private TileEntityBin tileEntityBin;
+
+		public BinItemHandler(TileEntityBin tileEntityBin)
+		{
+			this.tileEntityBin = tileEntityBin;
+		}
+
+		public int getSlots(){return 1;}
+
+		public ItemStack getStackInSlot(int slot)
+		{
+			if (slot != 0 || tileEntityBin.itemType == null)
+			{
+				return null;
+			}
+
+			return MekanismUtils.size(tileEntityBin.itemType, tileEntityBin.getItemCount());
+		}
+
+		public ItemStack insertItem(int slot, ItemStack stack, boolean simulate)
+		{
+			if (slot != 0)
+			{
+				return null;
+			}
+			return tileEntityBin.add(stack, simulate);
+
+		}
+
+		public ItemStack extractItem(int slot, int amount, boolean simulate)
+		{
+			if (slot != 0)
+			{
+				return null;
+			}
+
+			return tileEntityBin.remove(amount, simulate);
+		}
 	}
 }


### PR DESCRIPTION
Adds support for ItemHandler capability, exposing the stored items as a 1 slot inventory.

Like the DSU interface I left it as non-sided, and added simulate parameters to the add/remove functions, in order to not duplicate functionality.

Subclass was used because getStackInSlot works differently.

Benefits: things like AE2 & Refined Storage should be able to work with bins without any external dependencies.