### PR TITLE
Do not extract steam as a gas from a reactor - Fixes #4067

### DIFF
--- a/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorPort.java
+++ b/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorPort.java
@@ -198,14 +198,6 @@ public class TileEntityReactorPort extends TileEntityReactorBlock implements IFl
 	@Override
 	public GasStack drawGas(EnumFacing side, int amount, boolean doTransfer)
 	{
-		if(getReactor() != null)
-		{
-			if(getReactor().getSteamTank().getFluidAmount() > 0)
-			{
-				return new GasStack(GasRegistry.getGas("steam"), getReactor().getSteamTank().drain(amount, doTransfer).amount);
-			}
-		}
-
 		return null;
 	}
 
@@ -218,7 +210,7 @@ public class TileEntityReactorPort extends TileEntityReactorBlock implements IFl
 	@Override
 	public boolean canDrawGas(EnumFacing side, Gas type)
 	{
-		return (type == GasRegistry.getGas("steam"));
+		return false;
 	}
 
 	@Override


### PR DESCRIPTION
The reactor tries to extract the gas "steam". It'ss not registred in the GasRegistry. Therefor a GasStack with type null is being created, which could also throw a bunch of NPE's.
You're still able to extract steam as a fluid.

Fixes #4067 