### PR TITLE
Fix turbine not returning energy capability - Fixes #4097

### DIFF
--- a/src/main/java/mekanism/generators/common/tile/turbine/TileEntityTurbineValve.java
+++ b/src/main/java/mekanism/generators/common/tile/turbine/TileEntityTurbineValve.java
@@ -440,6 +440,11 @@ public class TileEntityTurbineValve extends TileEntityTurbineCasing implements I
 	{
 		if((!worldObj.isRemote && structure != null) || (worldObj.isRemote && clientHasStructure))
 		{
+			if(capability == Capabilities.ENERGY_STORAGE_CAPABILITY || capability == Capabilities.CABLE_OUTPUTTER_CAPABILITY)
+			{
+				return (T)this;
+			}
+
 			if(capability == CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY)
 			{
 				return (T)new FluidHandlerWrapper(this, side);


### PR DESCRIPTION
Turbine declared it has the energy storage and cable outputter capability with hasCapability, but didn't provide them with getCapability.

Closes #4097 
