### PR TITLE
Allow Axe enchantments on MekanismAxe - Fixes #4122.

### DIFF
--- a/src/main/java/mekanism/tools/item/ItemMekanismAxe.java
+++ b/src/main/java/mekanism/tools/item/ItemMekanismAxe.java
@@ -1,34 +1,32 @@
 package mekanism.tools.item;
 
-import java.util.Set;
+import java.util.List;
 
+import mekanism.api.util.StackUtils;
+import mekanism.common.Mekanism;
+import mekanism.common.util.LangUtils;
 import mekanism.tools.common.MekanismTools;
-import net.minecraft.block.Block;
-import net.minecraft.block.material.Material;
-import net.minecraft.block.state.IBlockState;
-import net.minecraft.init.Blocks;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemAxe;
 import net.minecraft.item.ItemStack;
 
-import com.google.common.collect.Sets;
-
-public class ItemMekanismAxe extends ItemMekanismTool
+public class ItemMekanismAxe extends ItemAxe
 {
-	private static final Set<Block> EFFECTIVE_ON = Sets.newHashSet(new Block[] {Blocks.PLANKS, Blocks.BOOKSHELF, Blocks.LOG, Blocks.LOG2, Blocks.CHEST, Blocks.PUMPKIN, Blocks.LIT_PUMPKIN, Blocks.MELON_BLOCK, Blocks.LADDER, Blocks.WOODEN_BUTTON, Blocks.WOODEN_PRESSURE_PLATE});
-
 	public ItemMekanismAxe(ToolMaterial tool)
 	{
-		super(MekanismTools.AXE_DAMAGE.get(tool), MekanismTools.AXE_SPEED.get(tool), tool, EFFECTIVE_ON);
+		super(tool, MekanismTools.AXE_DAMAGE.get(tool), MekanismTools.AXE_SPEED.get(tool));
+		setCreativeTab(Mekanism.tabMekanism);
 	}
 
 	@Override
-	public float getStrVsBlock(ItemStack itemstack, IBlockState blockState)
+	public void addInformation(ItemStack itemstack, EntityPlayer entityplayer, List list, boolean flag)
 	{
-		if(blockState != null && blockState.getBlock() != null && blockState.getMaterial() == Material.WOOD)
-		{
-			return efficiencyOnProperMaterial;
-		}
-		else {
-			return super.getStrVsBlock(itemstack, blockState);
-		}
+		list.add(LangUtils.localize("tooltip.hp") + ": " + (itemstack.getMaxDamage() - itemstack.getItemDamage()));
+	}
+
+	@Override
+	public boolean getIsRepairable(ItemStack stack1, ItemStack stack2)
+	{
+		return StackUtils.equalsWildcard(ItemMekanismTool.getRepairStack(toolMaterial), stack2) || super.getIsRepairable(stack1, stack2);
 	}
 }

--- a/src/main/java/mekanism/tools/item/ItemMekanismSword.java
+++ b/src/main/java/mekanism/tools/item/ItemMekanismSword.java
@@ -2,6 +2,7 @@ package mekanism.tools.item;
 
 import java.util.List;
 
+import mekanism.api.util.StackUtils;
 import mekanism.common.Mekanism;
 import mekanism.common.util.LangUtils;
 import net.minecraft.entity.player.EntityPlayer;
@@ -10,9 +11,12 @@ import net.minecraft.item.ItemSword;
 
 public class ItemMekanismSword extends ItemSword
 {
+	private ToolMaterial toolMaterial;
+
 	public ItemMekanismSword(ToolMaterial enumtoolmaterial)
 	{
 		super(enumtoolmaterial);
+		toolMaterial = enumtoolmaterial;
 		setCreativeTab(Mekanism.tabMekanism);
 	}
 
@@ -20,5 +24,11 @@ public class ItemMekanismSword extends ItemSword
 	public void addInformation(ItemStack itemstack, EntityPlayer entityplayer, List list, boolean flag)
 	{
 		list.add(LangUtils.localize("tooltip.hp") + ": " + (itemstack.getMaxDamage() - itemstack.getItemDamage()));
+	}
+
+	@Override
+	public boolean getIsRepairable(ItemStack stack1, ItemStack stack2)
+	{
+		return StackUtils.equalsWildcard(ItemMekanismTool.getRepairStack(toolMaterial), stack2) || super.getIsRepairable(stack1, stack2);
 	}
 }


### PR DESCRIPTION
Changes the Axe from an ItemMekanismTool to ItemAxe.
- Copied the methods addInformation and getIsRepairable to the MekanismAxe class.
- Removed EFFECTIVE_ON as it's the same as the one defined by ItemAxe
- Removed getStrVsBlock as it's almost the same as the one defined by ItemAxe

Allow MekanismSword to be repaired with ingots.