### PR TITLE
Fix for #4233: out-of-bounds error in thermal evaporation render, which crashes client.

### DIFF
--- a/src/main/java/mekanism/client/render/tileentity/RenderThermalEvaporationController.java
+++ b/src/main/java/mekanism/client/render/tileentity/RenderThermalEvaporationController.java
@@ -46,7 +46,10 @@ public class RenderThermalEvaporationController extends TileEntitySpecialRendere
 				MekanismRenderer.glowOn(tileEntity.inputTank.getFluid().getFluid().getLuminosity());
 
 				DisplayInteger[] displayList = getListAndRender(data, tileEntity.inputTank.getFluid().getFluid());
-				displayList[(int)(((float)tileEntity.inputTank.getFluidAmount()/tileEntity.inputTank.getCapacity())*((float)getStages(data.height)-1))].render();
+
+				float tankFillPercentage = Math.min(((float)tileEntity.inputTank.getFluidAmount()/tileEntity.inputTank.getCapacity()), 1);
+
+				displayList[(int)(tankFillPercentage * ((float)getStages(data.height)-1))].render();
 
 				MekanismRenderer.glowOff();
 


### PR DESCRIPTION
Thermal Evaporation Plant will no longer attempt to render with a fluid-level that is higher than its max capacity.