### PR TITLE
Change gastank to non full cube.

### DIFF
--- a/src/main/java/mekanism/common/block/BlockGasTank.java
+++ b/src/main/java/mekanism/common/block/BlockGasTank.java
@@ -42,7 +42,7 @@ import buildcraft.api.tools.IToolWrench;
 
 public class BlockGasTank extends BlockContainer
 {
-	private static final AxisAlignedBB TANK_BOUNDS = new AxisAlignedBB(0.2F, 0.0F, 0.2F, 0.8F, 1.0F, 0.8F);
+	private static final AxisAlignedBB TANK_BOUNDS = new AxisAlignedBB(0.1875F, 0.0F, 0.1875F, 0.8125F, 1.0F, 0.8125F);
 
 	public BlockGasTank()
 	{
@@ -365,6 +365,21 @@ public class BlockGasTank extends BlockContainer
 			}
 		}
 		
+		return false;
+	}
+
+	@Override
+	public boolean isFullBlock(IBlockState state) {
+		return false;
+	}
+
+	@Override
+	public boolean isFullCube(IBlockState state) {
+		return false;
+	}
+
+	@Override
+	public boolean isBlockSolid(IBlockAccess worldIn, BlockPos pos, EnumFacing side) {
 		return false;
 	}
 }


### PR DESCRIPTION
Resolves: #4232 

Currently the gas tank has a small bounding box, but is also a full cube which causes players to suffocate in them when walked into at head level and rubberbanding players when walked at feet level.

This commit changes:
- Gas tanks are non full blocks
- The bounding box aligned to 3/16th (0.1875) off a block

(Can be merged in 1.11 too)