### PR TITLE
Allow pipes to connect to IItemHandlers

### DIFF
--- a/src/main/java/mekanism/common/transmitters/grid/InventoryNetwork.java
+++ b/src/main/java/mekanism/common/transmitters/grid/InventoryNetwork.java
@@ -50,7 +50,7 @@ public class InventoryNetwork extends DynamicNetwork<TileEntity, InventoryNetwor
 			}
 			
 			EnumSet<EnumFacing> sides = acceptorDirections.get(coord);
-			IInventory acceptor = (IInventory)coord.getTileEntity(getWorld());
+			TileEntity acceptor = coord.getTileEntity(getWorld());
 			
 			if(sides == null || sides.isEmpty())
 			{
@@ -61,7 +61,7 @@ public class InventoryNetwork extends DynamicNetwork<TileEntity, InventoryNetwor
 			
 			for(EnumFacing side : sides)
 			{
-				ItemStack returned = TransporterManager.getPredictedInsert((TileEntity)acceptor, color, stack, side.getOpposite());
+				ItemStack returned = TransporterManager.getPredictedInsert(acceptor, color, stack, side.getOpposite());
 				
 				if(TransporterManager.didEmit(stack, returned))
 				{

--- a/src/main/java/mekanism/common/util/TransporterUtils.java
+++ b/src/main/java/mekanism/common/util/TransporterUtils.java
@@ -23,7 +23,7 @@ public final class TransporterUtils
 
 	public static boolean isValidAcceptorOnSide(TileEntity tile, EnumFacing side)
 	{
-		if(CapabilityUtils.hasCapability(tile, Capabilities.GRID_TRANSMITTER_CAPABILITY, side.getOpposite()) || !(tile instanceof IInventory))
+		if(CapabilityUtils.hasCapability(tile, Capabilities.GRID_TRANSMITTER_CAPABILITY, side.getOpposite()))
 		{
 			return false;
 		}


### PR DESCRIPTION
Allow pipes to connect to IItemHandler capability items and allow extraction from it. Insertion from pipes to IItemHandler not yet working.