### PR TITLE
Add scroll wheel support for GuiScrollList

### DIFF
--- a/src/main/java/mekanism/client/gui/GuiMekanism.java
+++ b/src/main/java/mekanism/client/gui/GuiMekanism.java
@@ -21,6 +21,7 @@ import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
 
 import org.lwjgl.input.Keyboard;
+import org.lwjgl.input.Mouse;
 
 public abstract class GuiMekanism extends GuiContainer implements IGuiWrapper
 {
@@ -256,6 +257,26 @@ public abstract class GuiMekanism extends GuiContainer implements IGuiWrapper
 	public void handleMouse(Slot slot, int slotIndex, int button, ClickType modifier)
 	{
 		handleMouseClick(slot, slotIndex, button, modifier);
+	}
+	
+	@Override
+	public void handleMouseInput() throws java.io.IOException
+	{
+		int xAxis = Mouse.getEventX() * this.width / this.mc.displayWidth - this.getXPos();
+		int yAxis = this.height - Mouse.getEventY() * this.height / this.mc.displayHeight - 1 - this.getYPos();
+		int delta = Mouse.getEventDWheel();
+		if (delta != 0) {
+			mouseWheel(xAxis, yAxis, delta);
+		}
+		super.handleMouseInput();
+	}
+	
+	public void mouseWheel(int xAxis, int yAxis, int delta)
+	{
+		for(GuiElement element : guiElements)
+		{
+			element.mouseWheel(xAxis, yAxis, delta);
+		}
 	}
 	
 	public int getXPos()

--- a/src/main/java/mekanism/client/gui/element/GuiElement.java
+++ b/src/main/java/mekanism/client/gui/element/GuiElement.java
@@ -126,6 +126,8 @@ public abstract class GuiElement
 
 	public void mouseReleased(int x, int y, int type) {}
 	
+	public void mouseWheel(int x, int y, int delta) {}
+	
 	public abstract Rectangle4i getBounds(int guiWidth, int guiHeight);
 
 	public abstract void renderBackground(int xAxis, int yAxis, int guiWidth, int guiHeight);

--- a/src/main/java/mekanism/client/gui/element/GuiScrollList.java
+++ b/src/main/java/mekanism/client/gui/element/GuiScrollList.java
@@ -244,4 +244,14 @@ public class GuiScrollList extends GuiElement
 			}
 		}
 	}
+	
+	@Override
+	public void mouseWheel(int x, int y, int delta)
+	{
+		if (x > xPosition && x < xPosition+xSize && y > yPosition && y < yPosition+size*10){
+			scroll = Math.min(Math.max(scroll - (delta / 120F) * (1F / textEntries.size()), 0), 1); // 120 = DirectInput factor for one notch. Linux/OSX LWGL scale accordingly
+			drawScroll();
+		}
+		super.mouseWheel(x, y, delta);
+	}
 }


### PR DESCRIPTION
Allows to use the mouse wheel to scroll in GuiScrollList. Mouse event is accessible on all GuiElements.