### PR TITLE
Check for null side in TileComponentConfig

### DIFF
--- a/src/main/java/mekanism/common/tile/component/TileComponentConfig.java
+++ b/src/main/java/mekanism/common/tile/component/TileComponentConfig.java
@@ -138,11 +138,20 @@ public class TileComponentConfig implements ITileComponent
 	
 	public SideData getOutput(TransmissionType type, EnumFacing side, EnumFacing facing)
 	{
+		if (side == null)
+		{
+			return EMPTY;
+		}
 		return getOutput(type, MekanismUtils.getBaseOrientation(side, facing));
 	}
 	
 	public SideData getOutput(TransmissionType type, EnumFacing side)
 	{
+		if (side == null)
+		{
+			return EMPTY;
+		}
+		
 		int index = getConfig(type)[side.ordinal()];
 		
 		if(index == -1)


### PR DESCRIPTION
Trying to insert into null side can cause null pointer in TileComponentConfig via getBaseOrientation. This makes it so the component returns EMPTY if a side isn't given.

Example: place an RFTools builder with configured pump card, Quantum Entangleporter on top. Instant crash.

Crash log from before this fix.
[crash-2017-05-06_13.15.22-server.txt](https://github.com/aidancbrady/Mekanism/files/980725/crash-2017-05-06_13.15.22-server.txt)
