### PR TITLE
Only allow same fluids in active fluidtank towers.

### DIFF
--- a/src/main/java/mekanism/common/tile/TileEntityFluidTank.java
+++ b/src/main/java/mekanism/common/tile/TileEntityFluidTank.java
@@ -564,10 +564,9 @@ public class TileEntityFluidTank extends TileEntityContainerBlock implements IAc
 	@Override
 	public boolean canFill(EnumFacing from, Fluid fluid)
 	{
+		TileEntity tile = world.getTileEntity(getPos().offset(EnumFacing.DOWN));
 		if(from == EnumFacing.DOWN && world != null && getPos() != null)
 		{
-			TileEntity tile = world.getTileEntity(getPos().offset(EnumFacing.DOWN));
-			
 			if(isActive && !(tile instanceof TileEntityFluidTank))
 			{
 				return false;
@@ -578,7 +577,13 @@ public class TileEntityFluidTank extends TileEntityContainerBlock implements IAc
 		{
 			return true;
 		}
-		
+
+		if(isActive && tile instanceof TileEntityFluidTank) // Only fill if tanks underneath have same fluid.
+		{
+			return (fluidTank.getFluid() == null && ((TileEntityFluidTank)tile).canFill(EnumFacing.UP, fluid)) ||
+					(fluidTank.getFluid() != null && fluidTank.getFluid().getFluid() == fluid);
+		}
+
 		return fluidTank.getFluid() == null || fluidTank.getFluid().getFluid() == fluid;
 	}
 


### PR DESCRIPTION
Implements feature #4165
If the current fluidtank is active and contains no fluid, check if the fluidtank underneath has the same fluid.
If it's the same as the one being inserted, accept the fluid. If they aren't the same, do not accept the fluid.
If the fluidtank underneath will execute the same checks if active.

Original behaviour is the same with non active fluidtanks.