### PR TITLE
fixed separator taking two upgrades instead of one

### DIFF
--- a/src/main/java/mekanism/common/tile/TileEntityElectrolyticSeparator.java
+++ b/src/main/java/mekanism/common/tile/TileEntityElectrolyticSeparator.java
@@ -79,8 +79,7 @@ public class TileEntityElectrolyticSeparator extends TileEntityMachine implement
 	public SeparatorRecipe cachedRecipe;
 	
 	public double clientEnergyUsed;
-	
-	public TileComponentUpgrade upgradeComponent = new TileComponentUpgrade(this, 4);
+
 	public TileComponentSecurity securityComponent = new TileComponentSecurity(this);
 
     /** This machine's current RedstoneControl type. */


### PR DESCRIPTION
Electrolitic separator contains  two instances of:
```java
public TileComponentUpgrade upgradeComponent = new TileComponentUpgrade(this, 4);
```
