### PR TITLE
Fixed IllegalArgumentException in OreDictCache class

### DIFF
--- a/src/main/java/mekanism/common/OreDictCache.java
+++ b/src/main/java/mekanism/common/OreDictCache.java
@@ -18,7 +18,7 @@ public final class OreDictCache
 
 	public static List<String> getOreDictName(ItemStack check)
 	{
-		if(check == null || check.getItem() == null)
+		if(check.isEmpty())
 		{
 			return new ArrayList<String>();
 		}


### PR DESCRIPTION
As in 1.11 Forge no longer allows ItemStacks to be null, you can change this condition to check.isEmpty(), which also fixes #4418 