### PR TITLE
Fixed reactor blocks dropping wrong items

### DIFF
--- a/src/main/java/mekanism/generators/common/block/BlockReactor.java
+++ b/src/main/java/mekanism/generators/common/block/BlockReactor.java
@@ -18,7 +18,7 @@ import mekanism.generators.common.tile.reactor.TileEntityReactorController;
 import mekanism.generators.common.tile.reactor.TileEntityReactorLogicAdapter;
 import mekanism.generators.common.tile.reactor.TileEntityReactorPort;
 import net.minecraft.block.Block;
-import net.minecraft.block.BlockContainer;
+import net.minecraft.block.ITileEntityProvider;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.properties.PropertyEnum;
 import net.minecraft.block.state.BlockStateContainer;
@@ -44,7 +44,7 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import buildcraft.api.tools.IToolWrench;
 
-public abstract class BlockReactor extends BlockContainer implements ICTMBlock
+public abstract class BlockReactor extends Block implements ICTMBlock, ITileEntityProvider
 {
 	public CTMData[] ctmData = new CTMData[16];
 


### PR DESCRIPTION
Also, you should consider changing all of your classes to implement ITileEntityProvider instead of extending BlockContainer and switch from ISidedInventory to Capabilities

Fixes #4420 