### PR TITLE
Fix integer overflows

### DIFF
--- a/src/main/java/mekanism/common/tile/TileEntityInductionPort.java
+++ b/src/main/java/mekanism/common/tile/TileEntityInductionPort.java
@@ -251,7 +251,7 @@ public class TileEntityInductionPort extends TileEntityInductionCasing implement
 				structure.remainingInput -= toAdd;
 			}
 
-			return (int)Math.round(toAdd*general.TO_RF);
+			return (int)Math.round(Math.min(Integer.MAX_VALUE, toAdd*general.TO_RF));
 		}
 
 		return 0;
@@ -270,7 +270,7 @@ public class TileEntityInductionPort extends TileEntityInductionCasing implement
 				structure.remainingOutput -= toSend;
 			}
 
-			return (int)Math.round(toSend*general.TO_RF);
+			return (int)Math.round(Math.min(Integer.MAX_VALUE, toSend*general.TO_RF));
 		}
 
 		return 0;
@@ -285,13 +285,13 @@ public class TileEntityInductionPort extends TileEntityInductionCasing implement
 	@Override
 	public int getEnergyStored(EnumFacing from)
 	{
-		return (int)Math.round(getEnergy()*general.TO_RF);
+		return (int)Math.round(Math.min(Integer.MAX_VALUE, getEnergy()*general.TO_RF));
 	}
 
 	@Override
 	public int getMaxEnergyStored(EnumFacing from)
 	{
-		return (int)Math.round(getMaxEnergy()*general.TO_RF);
+		return (int)Math.round(Math.min(Integer.MAX_VALUE, getMaxEnergy()*general.TO_RF));
 	}
 
 	@Override
@@ -322,7 +322,7 @@ public class TileEntityInductionPort extends TileEntityInductionCasing implement
 		double toUse = Math.min(Math.min(getMaxInput(), getMaxEnergy()-getEnergy()), amount*general.FROM_IC2);
 		setEnergy(getEnergy() + toUse);
 		structure.remainingInput -= toUse;
-		return (int)Math.round(getEnergy()*general.TO_IC2);
+		return (int)Math.round(Math.min(Integer.MAX_VALUE, getEnergy()*general.TO_IC2));
 	}
 
 	@Override
@@ -356,21 +356,21 @@ public class TileEntityInductionPort extends TileEntityInductionCasing implement
 	@Method(modid = "IC2")
 	public int getStored()
 	{
-		return (int)Math.round(getEnergy()*general.TO_IC2);
+		return (int)Math.round(Math.min(Integer.MAX_VALUE, getEnergy()*general.TO_IC2));
 	}
 
 	@Override
 	@Method(modid = "IC2")
 	public int getCapacity()
 	{
-		return (int)Math.round(getMaxEnergy()*general.TO_IC2);
+		return (int)Math.round(Math.min(Integer.MAX_VALUE, getMaxEnergy()*general.TO_IC2));
 	}
 
 	@Override
 	@Method(modid = "IC2")
 	public int getOutput()
 	{
-		return (int)Math.round(getMaxOutput()*general.TO_IC2);
+		return (int)Math.round(Math.min(Integer.MAX_VALUE, getMaxOutput()*general.TO_IC2));
 	}
 
 	@Override

--- a/src/main/java/mekanism/common/tile/prefab/TileEntityElectricBlock.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityElectricBlock.java
@@ -223,13 +223,13 @@ public abstract class TileEntityElectricBlock extends TileEntityContainerBlock i
 	@Override
 	public int receiveEnergy(EnumFacing from, int maxReceive, boolean simulate)
 	{
-		return (int)Math.round(acceptEnergy(from, maxReceive*general.FROM_RF, simulate)*general.TO_RF);
+		return (int)Math.round(Math.min(Integer.MAX_VALUE, acceptEnergy(from, maxReceive*general.FROM_RF, simulate)*general.TO_RF));
 	}
 
 	@Override
 	public int extractEnergy(EnumFacing from, int maxExtract, boolean simulate)
 	{
-		return (int)Math.round(pullEnergy(from, maxExtract*general.FROM_RF, simulate)*general.TO_RF);
+		return (int)Math.round(Math.min(Integer.MAX_VALUE, pullEnergy(from, maxExtract*general.FROM_RF, simulate)*general.TO_RF));
 	}
 
 	@Override
@@ -276,7 +276,7 @@ public abstract class TileEntityElectricBlock extends TileEntityContainerBlock i
 	public int addEnergy(int amount)
 	{
 		setEnergy(getEnergy() + amount*general.FROM_IC2);
-		return (int)Math.round(getEnergy()*general.TO_IC2);
+		return (int)Math.round(Math.min(Integer.MAX_VALUE, getEnergy()*general.TO_IC2));
 	}
 
 	@Override
@@ -310,21 +310,21 @@ public abstract class TileEntityElectricBlock extends TileEntityContainerBlock i
 	@Method(modid = "IC2")
 	public int getStored()
 	{
-		return (int)Math.round(getEnergy()*general.TO_IC2);
+		return (int)Math.round(Math.min(Integer.MAX_VALUE, getEnergy()*general.TO_IC2));
 	}
 
 	@Override
 	@Method(modid = "IC2")
 	public int getCapacity()
 	{
-		return (int)Math.round(getMaxEnergy()*general.TO_IC2);
+		return (int)Math.round(Math.min(Integer.MAX_VALUE, getMaxEnergy()*general.TO_IC2));
 	}
 
 	@Override
 	@Method(modid = "IC2")
 	public int getOutput()
 	{
-		return (int)Math.round(getMaxOutput()*general.TO_IC2);
+		return (int)Math.round(Math.min(Integer.MAX_VALUE, getMaxOutput()*general.TO_IC2));
 	}
 
 	@Override

--- a/src/main/java/mekanism/common/tile/transmitter/TileEntityUniversalCable.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntityUniversalCable.java
@@ -257,7 +257,7 @@ public class TileEntityUniversalCable extends TileEntityTransmitter<EnergyAccept
 	@Override
 	public int receiveEnergy(EnumFacing from, int maxReceive, boolean simulate)
 	{
-		return maxReceive - (int)Math.round(takeEnergy(maxReceive*general.FROM_RF, !simulate)*general.TO_RF);
+		return maxReceive - (int)Math.round(Math.min(Integer.MAX_VALUE, takeEnergy(maxReceive*general.FROM_RF, !simulate)*general.TO_RF));
 	}
 
 	@Override
@@ -269,13 +269,13 @@ public class TileEntityUniversalCable extends TileEntityTransmitter<EnergyAccept
 	@Override
 	public int getEnergyStored(EnumFacing from)
 	{
-		return (int)Math.round(getEnergy() * general.TO_RF);
+		return (int)Math.round(Math.min(Integer.MAX_VALUE, getEnergy()*general.TO_RF));
 	}
 
 	@Override
 	public int getMaxEnergyStored(EnumFacing from)
 	{
-		return (int)Math.round(getMaxEnergy() * general.TO_RF);
+		return (int)Math.round(Math.min(Integer.MAX_VALUE, getMaxEnergy()*general.TO_RF));
 	}
 
 	@Override

--- a/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorController.java
+++ b/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorController.java
@@ -206,7 +206,7 @@ public class TileEntityReactorController extends TileEntityReactorBlock implemen
 	}
 
 	@Override
-	public ArrayList getNetworkedData(ArrayList data)
+	public ArrayList<Object> getNetworkedData(ArrayList<Object> data)
 	{
 		super.getNetworkedData(data);
 

--- a/src/main/java/mekanism/generators/common/tile/turbine/TileEntityTurbineValve.java
+++ b/src/main/java/mekanism/generators/common/tile/turbine/TileEntityTurbineValve.java
@@ -192,7 +192,7 @@ public class TileEntityTurbineValve extends TileEntityTurbineCasing implements I
 				setEnergy(getEnergy() - toSend);
 			}
 
-			return (int)Math.round(toSend*general.TO_RF);
+			return (int)Math.round(Math.min(Integer.MAX_VALUE, toSend*general.TO_RF));
 		}
 
 		return 0;
@@ -207,13 +207,13 @@ public class TileEntityTurbineValve extends TileEntityTurbineCasing implements I
 	@Override
 	public int getEnergyStored(EnumFacing from)
 	{
-		return (int)Math.round(getEnergy()*general.TO_RF);
+		return (int)Math.round(Math.min(Integer.MAX_VALUE, getEnergy()*general.TO_RF));
 	}
 
 	@Override
 	public int getMaxEnergyStored(EnumFacing from)
 	{
-		return (int)Math.round(getMaxEnergy()*general.TO_RF);
+		return (int)Math.round(Math.min(Integer.MAX_VALUE, getMaxEnergy()*general.TO_RF));
 	}
 
 	@Override
@@ -275,21 +275,21 @@ public class TileEntityTurbineValve extends TileEntityTurbineCasing implements I
 	@Method(modid = "IC2")
 	public int getStored()
 	{
-		return (int)Math.round(getEnergy()*general.TO_IC2);
+		return (int)Math.round(Math.min(Integer.MAX_VALUE, getEnergy()*general.TO_IC2));
 	}
 
 	@Override
 	@Method(modid = "IC2")
 	public int getCapacity()
 	{
-		return (int)Math.round(getMaxEnergy()*general.TO_IC2);
+		return (int)Math.round(Math.min(Integer.MAX_VALUE, getMaxEnergy()*general.TO_IC2));
 	}
 
 	@Override
 	@Method(modid = "IC2")
 	public int getOutput()
 	{
-		return (int)Math.round(getMaxOutput()*general.TO_IC2);
+		return (int)Math.round(Math.min(Integer.MAX_VALUE, getMaxOutput()*general.TO_IC2));
 	}
 
 	@Override


### PR DESCRIPTION
Using Math.min to limit it to the max value of an integer.
Math.round(double a) returns a long and casting a long which is greater than the max int to an int will do all kind of things but the things you want it to do.