### PR TITLE
Improve travis compile time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,7 @@ cache:
     - $HOME/.gradle/wrapper/
 before_install:
  - chmod +x gradlew
+install:
+ - ./gradlew setupCIWorkspace
+script:
+ - ./gradlew check


### PR DESCRIPTION
Sped up the check time of Travis. It only checked it, but somehow if defined explicitly together with a minimal CI workspace reduces the run time by 50%.

Ran it twice (once to create the build cache):
https://travis-ci.org/thommy101/Mekanism/builds/239091571