### PR TITLE
Add Github issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,18 @@
+*Please use the search functionality before reporting an issue. Also take a look at the closed issues!*
+
+#### Issue description:
+
+
+#### Steps to reproduce:
+1.
+2.
+3.
+
+#### Version (make sure you are on the latest version before reporting):
+**Forge:** 
+**Mekanism:** 
+**Other relevant version:** 
+
+#### If a (crash)log is relevant for this issue, link it here: (_It's almost always relevant_)
+
+[gist/pastebin/etc link here]


### PR DESCRIPTION
Added an issue template, which will pre fill every issue with the content off ISSUE_TEMPLATE.md.
Will hopefully direct some to look at duplicate issues :)

Added to the master branch, as that's the one where Github looks for these files.