### PR TITLE
Fix oredict registration, moved to preinit

### DIFF
--- a/src/main/java/mekanism/common/Mekanism.java
+++ b/src/main/java/mekanism/common/Mekanism.java
@@ -1240,6 +1240,9 @@ public class Mekanism
 		MekanismItems.register();
 		MekanismBlocks.register();
 
+		//Integrate certain OreDictionary recipes
+		registerOreDict();
+
 		if(Loader.isModLoaded("mcmultipart")) 
 		{
 			//Set up multiparts
@@ -1315,9 +1318,6 @@ public class Mekanism
 				}
 			}
 		}
-		
-		//Integrate certain OreDictionary recipes
-		registerOreDict();
 
 		//Load this module
 		addRecipes();


### PR DESCRIPTION
Fixes cross mod integration of oredict metals. Dusts, ingots, blocks are now correctly registered with TinkersConstruct after moving registration of oredict entries to preinit instead of init.

Fixes #4463 and #4288