### PR TITLE
More Null ItemStack / Null Comparison

### DIFF
--- a/src/api/java/ic2/api/energy/prefab/BasicEnergyTile.java
+++ b/src/api/java/ic2/api/energy/prefab/BasicEnergyTile.java
@@ -220,7 +220,7 @@ abstract class BasicEnergyTile implements ILocatable, IEnergyTile {
 	 * @return true if energy was transferred
 	 */
 	public boolean charge(ItemStack stack) {
-		if (stack == null || !Info.isIc2Available() || getWorldObj().isRemote) return false;
+		if (stack == null || stack.isEmpty() || !Info.isIc2Available() || getWorldObj().isRemote) return false;
 
 		double amount = ElectricItem.manager.charge(stack, energyStored, Math.max(getSinkTier(), getSourceTier()), false, false);
 
@@ -237,7 +237,7 @@ abstract class BasicEnergyTile implements ILocatable, IEnergyTile {
 	 * @return true if energy was transferred
 	 */
 	public boolean discharge(ItemStack stack, double limit) {
-		if (stack == null || !Info.isIc2Available() || getWorldObj().isRemote) return false;
+		if (stack == null || stack.isEmpty() || !Info.isIc2Available() || getWorldObj().isRemote) return false;
 
 		double amount = capacity - energyStored;
 		if (amount <= 0) return false;

--- a/src/main/java/mekanism/api/Coord4D.java
+++ b/src/main/java/mekanism/api/Coord4D.java
@@ -218,7 +218,7 @@ public class Coord4D
 		
 		if(state == null || state == Blocks.AIR)
 		{
-			return null;
+			return ItemStack.EMPTY;
 		}
 		
 		return new ItemStack(state.getBlock(), 1, state.getBlock().getMetaFromState(state));

--- a/src/main/java/mekanism/client/gui/GuiChemicalCrystallizer.java
+++ b/src/main/java/mekanism/client/gui/GuiChemicalCrystallizer.java
@@ -2,6 +2,7 @@ package mekanism.client.gui;
 
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.Nullable;
 
 import mekanism.api.gas.Gas;
 import mekanism.api.gas.GasTank;
@@ -48,7 +49,7 @@ public class GuiChemicalCrystallizer extends GuiMekanism
 
 	public Gas prevGas;
 
-	public ItemStack renderStack;
+	public @Nullable ItemStack renderStack;
 
 	public int stackSwitch = 0;
 
@@ -125,7 +126,7 @@ public class GuiChemicalCrystallizer extends GuiMekanism
 			}
 		}
 
-		if(renderStack != null)
+		if(renderStack != null && !renderStack.isEmpty())
 		{
 			try {
 				GlStateManager.pushMatrix();

--- a/src/main/java/mekanism/client/gui/GuiDigitalMinerConfig.java
+++ b/src/main/java/mekanism/client/gui/GuiDigitalMinerConfig.java
@@ -7,6 +7,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nullable;
 
 import mekanism.api.Coord4D;
 import mekanism.api.EnumColor;
@@ -464,7 +465,7 @@ public class GuiDigitalMinerConfig extends GuiMekanism
 				{
 					MItemStackFilter itemFilter = (MItemStackFilter)filter;
 
-					if(itemFilter.itemType != null)
+					if(itemFilter.itemType != null && !itemFilter.itemType.isEmpty())
 					{
 						GlStateManager.pushMatrix();
 						RenderHelper.enableGUIStandardItemLighting();
@@ -484,12 +485,13 @@ public class GuiDigitalMinerConfig extends GuiMekanism
 						updateStackList(oreFilter);
 					}
 
-					if(oreDictStacks.get(filter).renderStack != null)
+					ItemStack renderStack = oreDictStacks.get(filter).renderStack;
+					if(renderStack != null && !renderStack.isEmpty())
 					{
 						try {
 							GlStateManager.pushMatrix();
 							RenderHelper.enableGUIStandardItemLighting();
-							itemRender.renderItemAndEffectIntoGUI(oreDictStacks.get(filter).renderStack, 59, yStart + 3);
+							itemRender.renderItemAndEffectIntoGUI(renderStack, 59, yStart + 3);
 							RenderHelper.disableStandardItemLighting();
 							GlStateManager.popMatrix();
 						} catch(Exception e) {}
@@ -501,7 +503,7 @@ public class GuiDigitalMinerConfig extends GuiMekanism
 				{
 					MMaterialFilter itemFilter = (MMaterialFilter)filter;
 
-					if(itemFilter.materialItem != null)
+					if(itemFilter.materialItem != null && !itemFilter.materialItem.isEmpty())
 					{
 						GlStateManager.pushMatrix();
 						RenderHelper.enableGUIStandardItemLighting();
@@ -521,12 +523,13 @@ public class GuiDigitalMinerConfig extends GuiMekanism
 						updateStackList(modFilter);
 					}
 
-					if(modIDStacks.get(filter).renderStack != null)
+					ItemStack renderStack = modIDStacks.get(filter).renderStack;
+					if(renderStack != null && !renderStack.isEmpty())
 					{
 						try {
 							GlStateManager.pushMatrix();
 							RenderHelper.enableGUIStandardItemLighting();
-							itemRender.renderItemAndEffectIntoGUI(modIDStacks.get(filter).renderStack, 59, yStart + 3);
+							itemRender.renderItemAndEffectIntoGUI(renderStack, 59, yStart + 3);
 							RenderHelper.disableStandardItemLighting();
 							GlStateManager.popMatrix();
 						} catch(Exception e) {}
@@ -762,7 +765,7 @@ public class GuiDigitalMinerConfig extends GuiMekanism
 	{
 		public List<ItemStack> iterStacks;
 		public int stackIndex;
-		public ItemStack renderStack;
+		public @Nullable ItemStack renderStack;
 	}
 
 	/**

--- a/src/main/java/mekanism/client/gui/GuiLogisticalSorter.java
+++ b/src/main/java/mekanism/client/gui/GuiLogisticalSorter.java
@@ -7,6 +7,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nullable;
 
 import mekanism.api.Coord4D;
 import mekanism.api.EnumColor;
@@ -471,7 +472,7 @@ public class GuiLogisticalSorter extends GuiMekanism
 				{
 					final TItemStackFilter itemFilter = (TItemStackFilter) filter;
 
-					if(itemFilter.itemType != null)
+					if(itemFilter.itemType != null && !itemFilter.itemType.isEmpty())
 					{
 						GlStateManager.pushMatrix();
 						RenderHelper.enableGUIStandardItemLighting();
@@ -492,12 +493,13 @@ public class GuiLogisticalSorter extends GuiMekanism
 						updateStackList(oreFilter);
 					}
 
-					if(oreDictStacks.get(filter).renderStack != null)
+					ItemStack renderStack = oreDictStacks.get(filter).renderStack;
+					if(renderStack != null && !renderStack.isEmpty())
 					{
 						try {
 							GlStateManager.pushMatrix();
 							RenderHelper.enableGUIStandardItemLighting();
-							itemRender.renderItemAndEffectIntoGUI(oreDictStacks.get(filter).renderStack, 59, yStart + 3);
+							itemRender.renderItemAndEffectIntoGUI(renderStack, 59, yStart + 3);
 							RenderHelper.disableStandardItemLighting();
 							GlStateManager.popMatrix();
 						} catch(final Exception e) {}
@@ -510,7 +512,7 @@ public class GuiLogisticalSorter extends GuiMekanism
 				{
 					final TMaterialFilter itemFilter = (TMaterialFilter) filter;
 
-					if(itemFilter.materialItem != null)
+					if(itemFilter.materialItem != null && !itemFilter.materialItem.isEmpty())
 					{
 						GlStateManager.pushMatrix();
 						RenderHelper.enableGUIStandardItemLighting();
@@ -531,12 +533,13 @@ public class GuiLogisticalSorter extends GuiMekanism
 						updateStackList(modFilter);
 					}
 
-					if(modIDStacks.get(filter).renderStack != null)
+					ItemStack renderStack = modIDStacks.get(filter).renderStack;
+					if(renderStack != null && !renderStack.isEmpty())
 					{
 						try {
 							GlStateManager.pushMatrix();
 							RenderHelper.enableGUIStandardItemLighting();
-							itemRender.renderItemAndEffectIntoGUI(modIDStacks.get(filter).renderStack, 59, yStart + 3);
+							itemRender.renderItemAndEffectIntoGUI(renderStack, 59, yStart + 3);
 							RenderHelper.disableStandardItemLighting();
 							GlStateManager.popMatrix();
 						} catch(final Exception e) {}
@@ -724,7 +727,7 @@ public class GuiLogisticalSorter extends GuiMekanism
 
 		public int stackIndex;
 
-		public ItemStack renderStack;
+		public @Nullable ItemStack renderStack;
 	}
 
 	/**

--- a/src/main/java/mekanism/client/gui/GuiOredictionificatorFilter.java
+++ b/src/main/java/mekanism/client/gui/GuiOredictionificatorFilter.java
@@ -2,6 +2,7 @@ package mekanism.client.gui;
 
 import java.io.IOException;
 import java.util.List;
+import javax.annotation.Nullable;
 
 import mekanism.api.Coord4D;
 import mekanism.client.sound.SoundHandler;
@@ -43,7 +44,7 @@ public class GuiOredictionificatorFilter extends GuiMekanism
 	
 	public boolean isNew;
 	
-	public ItemStack renderStack;
+	public @Nullable ItemStack renderStack;
 	
 	public GuiOredictionificatorFilter(EntityPlayer player, TileEntityOredictionificator tentity, int index)
 	{
@@ -149,7 +150,7 @@ public class GuiOredictionificatorFilter extends GuiMekanism
 			renderScaledText(filter.filter, 32, 38, 0x404040, 111);
 		}
 
-		if(renderStack != null)
+		if(renderStack != null && !renderStack.isEmpty())
 		{
 			try {
 				GlStateManager.pushMatrix();
@@ -177,7 +178,7 @@ public class GuiOredictionificatorFilter extends GuiMekanism
 		
 		if(xAxis >= 45 && xAxis <= 61 && yAxis >= 19 && yAxis <= 35)
 		{
-			if(renderStack != null)
+			if(renderStack != null && !renderStack.isEmpty())
 			{
 				String name = ItemRegistryUtils.getMod(renderStack);
 				String extra = name.equals("null") ? "" : " (" + name + ")";

--- a/src/main/java/mekanism/client/jei/crafting/ShapelessMekanismRecipeWrapper.java
+++ b/src/main/java/mekanism/client/jei/crafting/ShapelessMekanismRecipeWrapper.java
@@ -42,7 +42,7 @@ public class ShapelessMekanismRecipeWrapper extends BlankRecipeWrapper
 		List<List<ItemStack>> inputs = stackHelper.expandRecipeItemStackInputs(recipe.getInput());
 		ingredients.setInputLists(ItemStack.class, inputs);
 
-		if(recipeOutput != null) 
+		if(recipeOutput != null && !recipeOutput.isEmpty())
 		{
 			ingredients.setOutput(ItemStack.class, recipeOutput);
 		}

--- a/src/main/java/mekanism/client/render/obj/GlowPanelModel.java
+++ b/src/main/java/mekanism/client/render/obj/GlowPanelModel.java
@@ -63,7 +63,7 @@ public class GlowPanelModel extends OBJBakedModelBase
 	
 	public EnumColor getColor()
 	{
-		if(tempStack != null)
+		if(tempStack != null && !tempStack.isEmpty())
 		{
 			return EnumColor.DYES[tempStack.getItemDamage()];
 		}

--- a/src/main/java/mekanism/client/render/tileentity/RenderBin.java
+++ b/src/main/java/mekanism/client/render/tileentity/RenderBin.java
@@ -37,7 +37,7 @@ public class RenderBin extends TileEntitySpecialRenderer<TileEntityBin>
 	{
 		String amount = "";
 
-		if(itemType != null)
+		if(itemType != null && !itemType.isEmpty())
 		{
 			amount = Integer.toString(clientAmount);
 			
@@ -47,7 +47,7 @@ public class RenderBin extends TileEntitySpecialRenderer<TileEntityBin>
 			}
 		}
 
-		if(itemType != null)
+		if(itemType != null && !itemType.isEmpty())
 		{
 			GlStateManager.pushMatrix();
 

--- a/src/main/java/mekanism/common/block/BlockBasic.java
+++ b/src/main/java/mekanism/common/block/BlockBasic.java
@@ -410,7 +410,7 @@ public abstract class BlockBasic extends Block implements ICTMBlock
 
 			if(mop != null && mop.sideHit == bin.facing)
 			{
-				if(bin.bottomStack != null)
+				if(bin.bottomStack != null && !bin.bottomStack.isEmpty())
 				{
 					if(!player.isSneaking())
 					{

--- a/src/main/java/mekanism/common/block/BlockBounding.java
+++ b/src/main/java/mekanism/common/block/BlockBounding.java
@@ -76,7 +76,7 @@ public class BlockBounding extends Block
 			IBlockState state1 = world.getBlockState(tileEntity.mainPos);
 			return state1.getBlock().getPickBlock(state1, target, world, tileEntity.mainPos, player);
 		} catch(Exception e) {
-			return null;
+			return ItemStack.EMPTY;
 		}
 	}
 

--- a/src/main/java/mekanism/common/integration/OreDictManager.java
+++ b/src/main/java/mekanism/common/integration/OreDictManager.java
@@ -366,7 +366,7 @@ public final class OreDictManager
 					tempCrafting.setInventorySlotContents(0, log);
 					ItemStack resultEntry = MekanismUtils.findMatchingRecipe(tempCrafting, null);
 
-					if(resultEntry != null)
+					if(resultEntry != null && !resultEntry.isEmpty())
 					{
 						RecipeHandler.addPrecisionSawmillRecipe(log, StackUtils.size(resultEntry, 6), new ItemStack(MekanismItems.Sawdust), 1);
 					}
@@ -377,7 +377,7 @@ public final class OreDictManager
 				tempCrafting.setInventorySlotContents(0, log);
 				ItemStack resultEntry = MekanismUtils.findMatchingRecipe(tempCrafting, null);
 
-				if(resultEntry != null)
+				if(resultEntry != null && !resultEntry.isEmpty())
 				{
 					RecipeHandler.addPrecisionSawmillRecipe(log, StackUtils.size(resultEntry, 6), new ItemStack(MekanismItems.Sawdust), 1);
 				}

--- a/src/main/java/mekanism/common/integration/WailaDataProvider.java
+++ b/src/main/java/mekanism/common/integration/WailaDataProvider.java
@@ -50,7 +50,7 @@ public class WailaDataProvider implements IWailaDataProvider
 	@Method(modid = "Waila")
 	public ItemStack getWailaStack(IWailaDataAccessor accessor, IWailaConfigHandler config)
 	{
-		return null;
+		return ItemStack.EMPTY;
 	}
 
 	@Override

--- a/src/main/java/mekanism/common/inventory/container/ContainerElectricPump.java
+++ b/src/main/java/mekanism/common/inventory/container/ContainerElectricPump.java
@@ -74,13 +74,13 @@ public class ContainerElectricPump extends Container
 				{
 					if(!mergeItemStack(slotStack, 2, 3, false))
 					{
-						return null;
+						return ItemStack.EMPTY;
 					}
 				}
 				else {
 					if(!mergeItemStack(slotStack, 3, inventorySlots.size(), true))
 					{
-						return null;
+						return ItemStack.EMPTY;
 					}
 				}
 			}
@@ -90,14 +90,14 @@ public class ContainerElectricPump extends Container
 				{
 					if(!mergeItemStack(slotStack, 0, 1, false))
 					{
-						return null;
+						return ItemStack.EMPTY;
 					}
 				}
 				else if(slotID == 0)
 				{
 					if(!mergeItemStack(slotStack, 3, inventorySlots.size(), true))
 					{
-						return null;
+						return ItemStack.EMPTY;
 					}
 				}
 			}
@@ -105,7 +105,7 @@ public class ContainerElectricPump extends Container
 			{
 				if(!mergeItemStack(slotStack, 3, inventorySlots.size(), true))
 				{
-					return null;
+					return ItemStack.EMPTY;
 				}
 			}
 			else {
@@ -113,20 +113,20 @@ public class ContainerElectricPump extends Container
 				{
 					if(!mergeItemStack(slotStack, 30, inventorySlots.size(), false))
 					{
-						return null;
+						return ItemStack.EMPTY;
 					}
 				}
 				else if(slotID > 29)
 				{
 					if(!mergeItemStack(slotStack, 3, 29, false))
 					{
-						return null;
+						return ItemStack.EMPTY;
 					}
 				}
 				else {
 					if(!mergeItemStack(slotStack, 3, inventorySlots.size(), true))
 					{
-						return null;
+						return ItemStack.EMPTY;
 					}
 				}
 			}
@@ -141,7 +141,7 @@ public class ContainerElectricPump extends Container
 
 			if(slotStack.getCount() == stack.getCount())
 			{
-				return null;
+				return ItemStack.EMPTY;
 			}
 
 			currentSlot.onTake(player, slotStack);

--- a/src/main/java/mekanism/common/item/ItemBlockBasic.java
+++ b/src/main/java/mekanism/common/item/ItemBlockBasic.java
@@ -204,7 +204,7 @@ public class ItemBlockBasic extends ItemBlock implements IEnergizedItem, ITierIt
 		{
 			if(!ItemDataUtils.hasData(stack, "newCount"))
 			{
-				return null;
+				return ItemStack.EMPTY;
 			}
 			
 			int newCount = ItemDataUtils.getInt(stack, "newCount");
@@ -216,7 +216,7 @@ public class ItemBlockBasic extends ItemBlock implements IEnergizedItem, ITierIt
             return ret;
 		}
 
-		return null;
+		return ItemStack.EMPTY;
 	}
 
 	@Override

--- a/src/main/java/mekanism/common/item/ItemBlockBasic.java
+++ b/src/main/java/mekanism/common/item/ItemBlockBasic.java
@@ -243,7 +243,7 @@ public class ItemBlockBasic extends ItemBlock implements IEnergizedItem, ITierIt
 				
 				tileEntity.tier = BinTier.values()[getBaseTier(stack).ordinal()];
 
-				if(inv.getItemType() != null)
+				if(!inv.getItemType().isEmpty())
 				{
 					tileEntity.setItemType(inv.getItemType());
 				}

--- a/src/main/java/mekanism/common/item/ItemProxy.java
+++ b/src/main/java/mekanism/common/item/ItemProxy.java
@@ -49,7 +49,7 @@ public class ItemProxy extends Item
 			return InventoryUtils.loadFromNBT(ItemDataUtils.getCompound(stack, "savedItem"));
 		}
 
-		return null;
+		return ItemStack.EMPTY;
 	}
 
 	@Override

--- a/src/main/java/mekanism/common/item/ItemProxy.java
+++ b/src/main/java/mekanism/common/item/ItemProxy.java
@@ -26,12 +26,12 @@ public class ItemProxy extends Item
 	@Override
 	public boolean hasContainerItem(ItemStack itemStack)
 	{
-		return getSavedItem(itemStack) != null;
+		return !getSavedItem(itemStack).isEmpty();
 	}
 
 	public void setSavedItem(ItemStack stack, ItemStack save)
 	{
-		if(save == null)
+		if(save == null || save.isEmpty())
 		{
 			ItemDataUtils.setBoolean(stack, "hasStack", false);
 			ItemDataUtils.removeData(stack, "savedItem");

--- a/src/main/java/mekanism/common/recipe/inputs/InfusionInput.java
+++ b/src/main/java/mekanism/common/recipe/inputs/InfusionInput.java
@@ -53,7 +53,7 @@ public class InfusionInput extends MachineInput<InfusionInput>
 	@Override
 	public boolean isValid()
 	{
-		return infuse.type != null && inputStack != null;
+		return infuse.type != null && inputStack != null && !inputStack.isEmpty();
 	}
 
 	public boolean use(NonNullList<ItemStack> inventory, int index, InfuseStorage infuseStorage, boolean deplete)

--- a/src/main/java/mekanism/common/recipe/inputs/MachineInput.java
+++ b/src/main/java/mekanism/common/recipe/inputs/MachineInput.java
@@ -27,7 +27,7 @@ public abstract class MachineInput<INPUT extends MachineInput<INPUT>>
 	
 	public static boolean inputContains(ItemStack container, ItemStack contained)
 	{
-		if(container != null && container.getCount() >= contained.getCount())
+		if(container != null && !container.isEmpty() && container.getCount() >= contained.getCount())
 		{
 			if(MekanismUtils.getOreDictName(container).contains("treeSapling"))
 			{

--- a/src/main/java/mekanism/common/tile/TileEntityAdvancedBoundingBlock.java
+++ b/src/main/java/mekanism/common/tile/TileEntityAdvancedBoundingBlock.java
@@ -56,7 +56,7 @@ public class TileEntityAdvancedBoundingBlock extends TileEntityBoundingBlock imp
 	{
 		if(getInv() == null)
 		{
-			return null;
+			return ItemStack.EMPTY;
 		}
 
 		return getInv().getStackInSlot(i);
@@ -67,7 +67,7 @@ public class TileEntityAdvancedBoundingBlock extends TileEntityBoundingBlock imp
 	{
 		if(getInv() == null)
 		{
-			return null;
+			return ItemStack.EMPTY;
 		}
 
 		return getInv().decrStackSize(i, j);
@@ -78,7 +78,7 @@ public class TileEntityAdvancedBoundingBlock extends TileEntityBoundingBlock imp
 	{
 		if(getInv() == null)
 		{
-			return null;
+			return ItemStack.EMPTY;
 		}
 
 		return getInv().removeStackFromSlot(i);

--- a/src/main/java/mekanism/common/tile/TileEntityBin.java
+++ b/src/main/java/mekanism/common/tile/TileEntityBin.java
@@ -740,7 +740,7 @@ public class TileEntityBin extends TileEntityBasicBlock implements ISidedInvento
 		@Override
 		public ItemStack getStackInSlot(int slot)
 		{
-			if(slot != 0 || tileEntityBin.itemType == null)
+			if(slot != 0 || tileEntityBin.itemType == null || tileEntityBin.itemType.isEmpty())
 			{
 				return ItemStack.EMPTY;
 			}

--- a/src/main/java/mekanism/common/tile/prefab/TileEntityContainerBlock.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityContainerBlock.java
@@ -86,11 +86,12 @@ public abstract class TileEntityContainerBlock extends TileEntityBasicBlock impl
 
 			for(int slotCount = 0; slotCount < getSizeInventory(); slotCount++)
 			{
-				if(getStackInSlot(slotCount) != null)
+				ItemStack stackInSlot = getStackInSlot(slotCount);
+				if(!stackInSlot.isEmpty())
 				{
 					NBTTagCompound tagCompound = new NBTTagCompound();
 					tagCompound.setByte("Slot", (byte)slotCount);
-					getStackInSlot(slotCount).writeToNBT(tagCompound);
+					stackInSlot.writeToNBT(tagCompound);
 					tagList.appendTag(tagCompound);
 				}
 			}

--- a/src/main/java/mekanism/common/util/MekanismUtils.java
+++ b/src/main/java/mekanism/common/util/MekanismUtils.java
@@ -970,7 +970,7 @@ public final class MekanismUtils
 		{
 			Object obj = itr.next();
 
-			if(obj instanceof IRecipe && ((IRecipe)obj).getRecipeOutput() != null)
+			if(obj instanceof IRecipe && ((IRecipe)obj).getRecipeOutput() != null && !((IRecipe)obj).getRecipeOutput().isEmpty())
 			{
 				for(ItemStack itemStack : itemStacks)
 				{

--- a/src/main/java/mekanism/common/util/RecipeUtils.java
+++ b/src/main/java/mekanism/common/util/RecipeUtils.java
@@ -116,7 +116,7 @@ public class RecipeUtils
 					{
 						if(!((IGasItem)toReturn.getItem()).canReceiveGas(toReturn, stored.getGas()))
 						{
-							return null;
+							return ItemStack.EMPTY;
 						}
 						
 						if(gasFound == null)
@@ -126,7 +126,7 @@ public class RecipeUtils
 						else {
 							if(gasFound.getGas() != stored.getGas())
 							{
-								return null;
+								return ItemStack.EMPTY;
 							}
 							
 							gasFound.amount += stored.amount;
@@ -174,7 +174,7 @@ public class RecipeUtils
 					{
 						if(FluidUtil.getFluidHandler(itemstack).fill(stored, false) == 0)
 						{
-							return null;
+							return ItemStack.EMPTY;
 						}
 						
 						if(fluidFound == null)
@@ -184,7 +184,7 @@ public class RecipeUtils
 						else {
 							if(fluidFound.getFluid() != stored.getFluid())
 							{
-								return null;
+								return ItemStack.EMPTY;
 							}
 							
 							fluidFound.amount += stored.amount;

--- a/src/main/java/mekanism/generators/client/gui/GuiReactorLogicAdapter.java
+++ b/src/main/java/mekanism/generators/client/gui/GuiReactorLogicAdapter.java
@@ -20,6 +20,7 @@ import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.RenderHelper;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.init.SoundEvents;
+import net.minecraft.item.ItemStack;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
@@ -65,7 +66,7 @@ public class GuiReactorLogicAdapter extends GuiMekanism
 		{
 			if(xAxis >= 24 && xAxis <= 152 && yAxis >= 32+(22*type.ordinal()) && yAxis <= 32+22+(22*type.ordinal()))
 			{
-				displayTooltips(MekanismUtils.splitTooltip(type.getDescription(), null), xAxis, yAxis);
+				displayTooltips(MekanismUtils.splitTooltip(type.getDescription(), ItemStack.EMPTY), xAxis, yAxis);
 			}
 		}
 		

--- a/src/main/java/mekanism/generators/common/block/BlockGenerator.java
+++ b/src/main/java/mekanism/generators/common/block/BlockGenerator.java
@@ -639,7 +639,7 @@ public abstract class BlockGenerator extends BlockContainer implements ICTMBlock
 		
 		if(tileEntity == null)
 		{
-			return null;
+			return ItemStack.EMPTY;
 		}
 		
 		if(tileEntity instanceof ISecurityTile)


### PR DESCRIPTION
I found a way to get Idea to analyse for `null` being passed where `ItemStack` was expected and where `ItemStack` was compared with `null` and gave Mekanism a check over.

For some of them (especially the internal use ones) I've left the `!= null` there to ensure no null pointer errors - so you may wish to go over them to verify if they're still needed.