### PR TITLE
[1.11] Different factory issues.

### DIFF
--- a/src/main/java/mekanism/common/block/states/BlockStateMachine.java
+++ b/src/main/java/mekanism/common/block/states/BlockStateMachine.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 import mekanism.common.Mekanism;
 import mekanism.common.MekanismBlocks;
+import mekanism.common.Tier;
 import mekanism.common.Tier.BaseTier;
 import mekanism.common.base.IBlockType;
 import mekanism.common.base.IFactory.RecipeType;
@@ -84,7 +85,7 @@ public class BlockStateMachine extends ExtendedBlockState
 		super(block, new IProperty[] {BlockStateFacing.facingProperty, typeProperty, activeProperty, tierProperty, recipeProperty}, new IUnlistedProperty[] {BlockStateBasic.ctmProperty});
 	}
 
-	public static enum MachineBlock
+	public enum MachineBlock
 	{
 		MACHINE_BLOCK_1,
 		MACHINE_BLOCK_2,
@@ -118,16 +119,16 @@ public class BlockStateMachine extends ExtendedBlockState
 		}
 	}
 
-	public static enum MachineType implements IStringSerializable, IBlockType
+	public enum MachineType implements IStringSerializable, IBlockType
 	{
 		ENRICHMENT_CHAMBER(MachineBlock.MACHINE_BLOCK_1, 0, "EnrichmentChamber", 3, TileEntityEnrichmentChamber.class, true, false, true, Plane.HORIZONTAL, true),
 		OSMIUM_COMPRESSOR(MachineBlock.MACHINE_BLOCK_1, 1, "OsmiumCompressor", 4, TileEntityOsmiumCompressor.class, true, false, true, Plane.HORIZONTAL, true),
 		COMBINER(MachineBlock.MACHINE_BLOCK_1, 2, "Combiner", 5, TileEntityCombiner.class, true, false, true, Plane.HORIZONTAL, true),
 		CRUSHER(MachineBlock.MACHINE_BLOCK_1, 3, "Crusher", 6, TileEntityCrusher.class, true, false, true, Plane.HORIZONTAL, true),
 		DIGITAL_MINER(MachineBlock.MACHINE_BLOCK_1, 4, "DigitalMiner", 2, TileEntityDigitalMiner.class, true, true, true, Plane.HORIZONTAL, true),
-		BASIC_FACTORY(MachineBlock.MACHINE_BLOCK_1, 5, "Factory", 11, TileEntityFactory.class, true, false, true, Plane.HORIZONTAL, true),
-		ADVANCED_FACTORY(MachineBlock.MACHINE_BLOCK_1, 6, "Factory", 11, TileEntityAdvancedFactory.class, true, false, true, Plane.HORIZONTAL, true),
-		ELITE_FACTORY(MachineBlock.MACHINE_BLOCK_1, 7, "Factory", 11, TileEntityEliteFactory.class, true, false, true, Plane.HORIZONTAL, true),
+		BASIC_FACTORY(MachineBlock.MACHINE_BLOCK_1, 5, "Factory", 11, TileEntityFactory.class, true, false, true, Plane.HORIZONTAL, true, Tier.FactoryTier.BASIC),
+		ADVANCED_FACTORY(MachineBlock.MACHINE_BLOCK_1, 6, "Factory", 11, TileEntityAdvancedFactory.class, true, false, true, Plane.HORIZONTAL, true, Tier.FactoryTier.ADVANCED),
+		ELITE_FACTORY(MachineBlock.MACHINE_BLOCK_1, 7, "Factory", 11, TileEntityEliteFactory.class, true, false, true, Plane.HORIZONTAL, true, Tier.FactoryTier.ELITE),
 		METALLURGIC_INFUSER(MachineBlock.MACHINE_BLOCK_1, 8, "MetallurgicInfuser", 12, TileEntityMetallurgicInfuser.class, true, true, true, Plane.HORIZONTAL, false),
 		PURIFICATION_CHAMBER(MachineBlock.MACHINE_BLOCK_1, 9, "PurificationChamber", 15, TileEntityPurificationChamber.class, true, false, true, Plane.HORIZONTAL, true),
 		ENERGIZED_SMELTER(MachineBlock.MACHINE_BLOCK_1, 10, "EnergizedSmelter", 16, TileEntityEnergizedSmelter.class, true, false, true, Plane.HORIZONTAL, true),
@@ -172,8 +173,14 @@ public class BlockStateMachine extends ExtendedBlockState
 		public Collection<ShapedMekanismRecipe> blockRecipes = new HashSet<ShapedMekanismRecipe>();
 		public Predicate<EnumFacing> facingPredicate;
 		public boolean activable;
+		public Tier.FactoryTier factoryTier;
 
-		private MachineType(MachineBlock block, int i, String s, int j, Class<? extends TileEntity> tileClass, boolean electric, boolean model, boolean upgrades, Predicate<EnumFacing> predicate, boolean hasActiveTexture)
+		MachineType(MachineBlock block, int i, String s, int j, Class<? extends TileEntity> tileClass, boolean electric, boolean model, boolean upgrades, Predicate<EnumFacing> predicate, boolean hasActiveTexture)
+		{
+			this(block, i, s, j, tileClass, electric, model, upgrades, predicate, hasActiveTexture, null);
+		}
+
+		MachineType(MachineBlock block, int i, String s, int j, Class<? extends TileEntity> tileClass, boolean electric, boolean model, boolean upgrades, Predicate<EnumFacing> predicate, boolean hasActiveTexture, Tier.FactoryTier factoryTier)
 		{
 			typeBlock = block;
 			meta = i;
@@ -185,6 +192,7 @@ public class BlockStateMachine extends ExtendedBlockState
 			supportsUpgrades = upgrades;
 			facingPredicate = predicate;
 			activable = hasActiveTexture;
+			this.factoryTier = factoryTier;
 		}
 		
 		@Override
@@ -219,7 +227,7 @@ public class BlockStateMachine extends ExtendedBlockState
 
 		public static List<MachineType> getValidMachines()
 		{
-			List<MachineType> ret = new ArrayList<MachineType>();
+			List<MachineType> ret = new ArrayList<>();
 
 			for(MachineType type : MachineType.values())
 			{
@@ -397,6 +405,11 @@ public class BlockStateMachine extends ExtendedBlockState
 		public boolean hasActiveTexture()
 		{
 			return activable;
+		}
+
+		public boolean isFactory()
+		{
+			return factoryTier != null;
 		}
 	}
 

--- a/src/main/java/mekanism/common/item/ItemBlockMachine.java
+++ b/src/main/java/mekanism/common/item/ItemBlockMachine.java
@@ -698,26 +698,13 @@ public class ItemBlockMachine extends ItemBlock implements IEnergizedItem, ISpec
 	{
 		MachineType machineType = MachineType.get(Block.getBlockFromItem(itemStack.getItem()), itemStack.getItemDamage());
 
-		if(machineType == MachineType.BASIC_FACTORY || machineType == MachineType.ADVANCED_FACTORY || machineType == MachineType.ELITE_FACTORY)
+		if(machineType.isFactory())
 		{
 			// 200*tier.processes*recipeType.getEnergyUsage(); // From TileEntityFactory
-
 			RecipeType recipeType = RecipeType.values()[getRecipeType(itemStack)];
-
-			int tierProcess;
-			if (machineType == MachineType.BASIC_FACTORY)
-			{
-				tierProcess = Tier.FactoryTier.BASIC.processes;
-			}
-			else if (machineType == MachineType.ADVANCED_FACTORY)
-			{
-				tierProcess = Tier.FactoryTier.ADVANCED.processes;
-			}
-			else {
-				tierProcess = Tier.FactoryTier.ELITE.processes;
-			}
-
+			int tierProcess = machineType.factoryTier.processes;
 			double baseMaxEnergy = 200 * tierProcess * recipeType.getEnergyUsage();
+
 			return MekanismUtils.getMaxEnergy(itemStack, baseMaxEnergy);
 		}
 

--- a/src/main/java/mekanism/common/item/ItemBlockMachine.java
+++ b/src/main/java/mekanism/common/item/ItemBlockMachine.java
@@ -17,6 +17,7 @@ import mekanism.client.MekKeyHandler;
 import mekanism.client.MekanismClient;
 import mekanism.client.MekanismKeyHandler;
 import mekanism.common.Mekanism;
+import mekanism.common.Tier;
 import mekanism.common.Tier.BaseTier;
 import mekanism.common.Tier.FluidTankTier;
 import mekanism.common.Upgrade;
@@ -695,7 +696,32 @@ public class ItemBlockMachine extends ItemBlock implements IEnergizedItem, ISpec
 	@Override
 	public double getMaxEnergy(ItemStack itemStack)
 	{
-		return MekanismUtils.getMaxEnergy(itemStack, MachineType.get(Block.getBlockFromItem(itemStack.getItem()), itemStack.getItemDamage()).baseEnergy);
+		MachineType machineType = MachineType.get(Block.getBlockFromItem(itemStack.getItem()), itemStack.getItemDamage());
+
+		if(machineType == MachineType.BASIC_FACTORY || machineType == MachineType.ADVANCED_FACTORY || machineType == MachineType.ELITE_FACTORY)
+		{
+			// 200*tier.processes*recipeType.getEnergyUsage(); // From TileEntityFactory
+
+			RecipeType recipeType = RecipeType.values()[getRecipeType(itemStack)];
+
+			int tierProcess;
+			if (machineType == MachineType.BASIC_FACTORY)
+			{
+				tierProcess = Tier.FactoryTier.BASIC.processes;
+			}
+			else if (machineType == MachineType.ADVANCED_FACTORY)
+			{
+				tierProcess = Tier.FactoryTier.ADVANCED.processes;
+			}
+			else {
+				tierProcess = Tier.FactoryTier.ELITE.processes;
+			}
+
+			double baseMaxEnergy = 200 * tierProcess * recipeType.getEnergyUsage();
+			return MekanismUtils.getMaxEnergy(itemStack, baseMaxEnergy);
+		}
+
+		return MekanismUtils.getMaxEnergy(itemStack, machineType.baseEnergy);
 	}
 
 	@Override

--- a/src/main/java/mekanism/common/tile/TileEntityFactory.java
+++ b/src/main/java/mekanism/common/tile/TileEntityFactory.java
@@ -158,6 +158,8 @@ public class TileEntityFactory extends TileEntityMachine implements IComputerInt
 
 		gasTank = new GasTank(TileEntityAdvancedElectricMachine.MAX_GAS*tier.processes);
 		maxInfuse = BASE_MAX_INFUSE*tier.processes;
+
+		setRecipeType(recipeType);
 	}
 	
 	@Override


### PR DESCRIPTION
Fix smelting factories default max energy value.
Adresses #4510 

The fix for getMaxEnergy isn't the nicest, but I couldn't think of an other way to fix it for all usages.