### PR TITLE
Use FMLInterModComms.IMCEvent to process IMC messages

### DIFF
--- a/src/main/java/mekanism/common/Mekanism.java
+++ b/src/main/java/mekanism/common/Mekanism.java
@@ -1212,9 +1212,9 @@ public class Mekanism
 	}
 	
 	@EventHandler
-	public void loadComplete(FMLLoadCompleteEvent event)
+	public void loadComplete(FMLInterModComms.IMCEvent event)
 	{
-		new IMCHandler().onIMCEvent(FMLInterModComms.fetchRuntimeMessages(this));
+		new IMCHandler().onIMCEvent(event.getMessages());
 	}
 	
 	@EventHandler

--- a/src/main/java/mekanism/common/integration/IMCHandler.java
+++ b/src/main/java/mekanism/common/integration/IMCHandler.java
@@ -17,7 +17,6 @@ import net.minecraftforge.fml.common.registry.GameRegistry;
 
 public class IMCHandler
 {
-	@EventHandler
 	public void onIMCEvent(List<IMCMessage> messages)
 	{
 		for(IMCMessage msg : messages)


### PR DESCRIPTION
I noticed while working on Applied Llamagistics that IMC added recipes (e.g. crusher, enrichment) don't show in JEI - I assume this is because Mek's `LoadComplete` handler fires after JEI's.

So, two options: use the dedicated event or process in postInit.

`IMCHandler` could probably also be static since it's not directly an event handler - as far as Idea can tell it's only ever used in the one place.

The `LoadComplete` event seems to also be frowned upon judging from the Javadoc.