### PR TITLE
Suggested Integration Changes for AE2

### DIFF
--- a/src/main/java/mekanism/common/integration/MekanismHooks.java
+++ b/src/main/java/mekanism/common/integration/MekanismHooks.java
@@ -156,13 +156,6 @@ public final class MekanismHooks
 	@Method(modid = "appliedenergistics2")
 	public void registerAE2P2P() 
 	{
-		String energyP2P = "add-p2p-attunement-rf-power";
-		
-		if(IC2Loaded)
-		{
-			energyP2P = "add-p2p-attunement-ic2-power";
-		}
-		
 		for(TransmitterType type : TransmitterType.values())
 		{
 			if(type.getTransmission().equals(TransmissionType.ITEM))
@@ -179,7 +172,7 @@ public final class MekanismHooks
 			
 			if(type.getTransmission().equals(TransmissionType.ENERGY))
 			{
-				FMLInterModComms.sendMessage("appliedenergistics2", energyP2P, new ItemStack(MekanismBlocks.Transmitter, 1, type.ordinal()));
+				FMLInterModComms.sendMessage("appliedenergistics2", "add-p2p-attunement-forge-power", new ItemStack(MekanismBlocks.Transmitter, 1, type.ordinal()));
 				continue;
 			}
 

--- a/src/main/java/mekanism/common/integration/OreDictManager.java
+++ b/src/main/java/mekanism/common/integration/OreDictManager.java
@@ -160,7 +160,7 @@ public final class OreDictManager
 			} catch(Exception e) {}
 		}
 		
-		for(ItemStack ore : OreDictionary.getOres("oreCertusQuartz"))
+		/*for(ItemStack ore : OreDictionary.getOres("oreCertusQuartz"))
 		{
 			try {
 				RecipeHandler.addEnrichmentChamberRecipe(StackUtils.size(ore, 1), StackUtils.size(OreDictionary.getOres("dustCertusQuartz").get(0), 4));
@@ -179,7 +179,7 @@ public final class OreDictManager
 			try {
 				RecipeHandler.addEnrichmentChamberRecipe(StackUtils.size(ore, 1), StackUtils.size(OreDictionary.getOres("crystalCertusQuartz").get(0), 1));
 			} catch(Exception e) {}
-		}
+		}*/
 		
 		for(ItemStack ore : OreDictionary.getOres("gemQuartz"))
 		{
@@ -200,7 +200,7 @@ public final class OreDictManager
 			RecipeHandler.addEnrichmentChamberRecipe(StackUtils.size(ore, 1), new ItemStack(Items.QUARTZ, 6));
 		}
 		
-		for(ItemStack ore : OreDictionary.getOres("crystalFluix"))
+		/*for(ItemStack ore : OreDictionary.getOres("crystalFluix"))
 		{
 			try {
 				RecipeHandler.addCrusherRecipe(StackUtils.size(ore, 1), StackUtils.size(OreDictionary.getOres("dustFluix").get(0), 1));
@@ -212,7 +212,7 @@ public final class OreDictManager
 			try {
 				RecipeHandler.addEnrichmentChamberRecipe(StackUtils.size(ore, 1), StackUtils.size(OreDictionary.getOres("crystalFluix").get(0), 1));
 			} catch(Exception e) {}
-		}
+		}*/
 		
 		for(ItemStack ore : OreDictionary.getOres("ingotCopper"))
 		{


### PR DESCRIPTION
NB: this is mainly based on my for of AE2 for 1.11+, Applied Llamagistics.

1. Universal cables should be registered to be a ForgeEnergy tunnel attunement. You're free to register it conditionally as IC2 if you want though

2. Commented out recipes for Certus and Fluix processes, as I put back the integration on the AL side with its custom recipe system. I've left sand and nether quartz in because that's not exclusive to AL.
NB: this commit should **not** be merged to the 1.10 branch as such integration does not exist there.