### PR TITLE
[1.10 - compat] add back removed interfaces (and the capability just in case) 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,6 +128,10 @@ task MDKZip(type: Zip) {
     baseName = 'MDK'
     from sourceSets.main.java.srcDirs
     include 'mekanism/api/**'
+    exclude 'mekanism/api/energy/ICableOutputter.java'
+    exclude 'mekanism/api/gas/IGasTransmitter.java'
+    exclude 'mekanism/api/ItemRetriever.java'
+    exclude 'mekanism/api/reactor/**'
 }
 
 task releaseJars(type: Copy) {

--- a/src/main/java/mekanism/api/ItemRetriever.java
+++ b/src/main/java/mekanism/api/ItemRetriever.java
@@ -1,0 +1,115 @@
+package mekanism.api;
+
+import net.minecraft.block.Block;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+
+/**
+ * Use this class's 'getItem()' method to retrieve ItemStacks from the 'Mekanism'
+ * class.
+ * @author AidanBrady
+ *
+ * @deprecated backwards compatibility only.
+ *
+ */
+@Deprecated
+public final class ItemRetriever
+{
+	/** The 'MekanismItems' class that items are retrieved from. */
+	private static Class MekanismItems;
+	
+	/** The 'MekanismBlocks' class that blocks are retrieved from. */
+	private static Class MekanismBlocks;
+
+	/**
+	 * Attempts to retrieve an ItemStack of an item with the declared identifier.
+	 *
+	 * Mekanism identifiers follow an easy-to-remember pattern.  All identifiers
+	 * are identical to the String returned by 'getItemName().'  None include spaces,
+	 * and all start with a capital letter. The name that shows up in-game can be
+	 * stripped down to identifier form by removing spaces and all non-alphabetic
+	 * characters (,./'=-_). Below is an example:
+	 *
+	 * ItemStack enrichedAlloy = ItemRetriever.getItem("EnrichedAlloy");
+	 *
+	 * Note that for items or blocks that have specific metadata you will need to create
+	 * a new ItemStack with that specified value, as this will only return an ItemStack
+	 * with the meta value '0.'
+	 *
+	 * Make sure you run this in or after FMLPostInitializationEvent runs, because most
+	 * items are registered when FMLInitializationEvent runs. However, some items ARE
+	 * registered later in order to hook into other mods. In a rare circumstance you may
+	 * have to add "after:Mekanism" in the @Mod 'dependencies' annotation.
+	 *
+	 * @param identifier - a String to be searched in the 'MekanismItems' class
+	 * @return an ItemStack of the declared identifier, otherwise null.
+	 */
+	public static ItemStack getItem(String identifier)
+	{
+		try {
+			if(MekanismItems == null)
+			{
+				MekanismItems = Class.forName("mekanism.common.MekanismItems");
+			}
+
+			Object ret = MekanismItems.getField(identifier).get(null);
+
+			if(ret instanceof Item)
+			{
+				return new ItemStack((Item)ret, 1);
+			}
+			else {
+				return null;
+			}
+		} catch(Exception e) {
+			System.err.println("Error retrieving item with identifier '" + identifier + "': " + e.getMessage());
+			return null;
+		}
+	}
+	
+	/**
+	 * Attempts to retrieve an ItemStack of a block with the declared identifier.
+	 *
+	 * Mekanism identifiers follow an easy-to-remember pattern.  All identifiers
+	 * are identical to the String returned by 'getItemName().'  None include spaces,
+	 * and all start with a capital letter. The name that shows up in-game can be
+	 * stripped down to identifier form by removing spaces and all non-alphabetic
+	 * characters (,./'=-_). Below is an example:
+	 *
+	 * ItemStack enrichedAlloy = ItemRetriever.getItem("EnrichedAlloy");
+	 *
+	 * Note that for items or blocks that have specific metadata you will need to create
+	 * a new ItemStack with that specified value, as this will only return an ItemStack
+	 * with the meta value '0.'
+	 *
+	 * Make sure you run this in or after FMLPostInitializationEvent runs, because most
+	 * items are registered when FMLInitializationEvent runs. However, some items ARE
+	 * registered later in order to hook into other mods. In a rare circumstance you may
+	 * have to add "after:Mekanism" in the @Mod 'dependencies' annotation.
+	 *
+	 * @param identifier - a String to be searched in the 'MekanismBlocks' class
+	 * @return an ItemStack of the declared identifier, otherwise null.
+	 */
+	public static ItemStack getBlock(String identifier)
+	{
+		try {
+			if(MekanismBlocks == null)
+			{
+				MekanismBlocks = Class.forName("mekanism.common.MekanismBlocks");
+			}
+
+			Object ret = MekanismBlocks.getField(identifier).get(null);
+
+			if(ret instanceof Block)
+			{
+				return new ItemStack((Block)ret, 1);
+			}
+			else {
+				return null;
+			}
+		} catch(Exception e) {
+			System.err.println("Error retrieving block with identifier '" + identifier + "': " + e.getMessage());
+			return null;
+		}
+	}
+}

--- a/src/main/java/mekanism/api/energy/ICableOutputter.java
+++ b/src/main/java/mekanism/api/energy/ICableOutputter.java
@@ -1,0 +1,13 @@
+package mekanism.api.energy;
+
+import net.minecraft.util.EnumFacing;
+
+/**
+ * @deprecated functionality has been replaced by {@link IStrictEnergyOutputter#canOutputEnergy(net.minecraft.util.EnumFacing)}
+ * Class remains solely to prevent crashes on load
+ */
+@Deprecated
+public interface ICableOutputter
+{
+	public boolean canOutputTo(EnumFacing side);
+}

--- a/src/main/java/mekanism/api/gas/IGasTransmitter.java
+++ b/src/main/java/mekanism/api/gas/IGasTransmitter.java
@@ -1,0 +1,14 @@
+package mekanism.api.gas;
+
+import mekanism.api.transmitters.IGridTransmitter;
+import mekanism.common.transmitters.grid.GasNetwork;
+import net.minecraft.tileentity.TileEntity;
+
+/**
+ * @deprecated - no longer in use, remains present only for backwards compatibility crash avoidance.
+ */
+@Deprecated
+public interface IGasTransmitter extends IGridTransmitter<IGasHandler, GasNetwork>
+{
+	public boolean canTransferGasToTube(TileEntity tile);
+}

--- a/src/main/java/mekanism/api/reactor/IFusionReactor.java
+++ b/src/main/java/mekanism/api/reactor/IFusionReactor.java
@@ -1,0 +1,66 @@
+package mekanism.api.reactor;
+
+import mekanism.api.IHeatTransfer;
+import mekanism.api.gas.GasTank;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.FluidTank;
+
+@Deprecated
+public interface IFusionReactor extends IHeatTransfer
+{
+	public void addTemperatureFromEnergyInput(double energyAdded);
+
+	public void simulate();
+
+	public FluidTank getWaterTank();
+
+	public FluidTank getSteamTank();
+
+	public GasTank getDeuteriumTank();
+
+	public GasTank getTritiumTank();
+
+	public GasTank getFuelTank();
+
+	public double getBufferedEnergy();
+
+	public void setBufferedEnergy(double energy);
+
+	public double getPlasmaTemp();
+
+	public void setPlasmaTemp(double temp);
+
+	public double getCaseTemp();
+
+	public void setCaseTemp(double temp);
+
+	public double getBufferSize();
+
+	public void formMultiblock(boolean keepBurning);
+
+	public boolean isFormed();
+
+	public void setInjectionRate(int rate);
+
+	public int getInjectionRate();
+
+	public boolean isBurning();
+
+	public void setBurning(boolean burn);
+
+	public int getMinInjectionRate(boolean active);
+
+	public double getMaxPlasmaTemperature(boolean active);
+
+	public double getMaxCasingTemperature(boolean active);
+
+	public double getIgnitionTemperature(boolean active);
+
+	public double getPassiveGeneration(boolean active, boolean current);
+
+	public int getSteamPerTick(boolean current);
+
+	public void updateTemperatures();
+	
+	public ItemStack[] getInventory();
+}

--- a/src/main/java/mekanism/api/reactor/INeutronCapture.java
+++ b/src/main/java/mekanism/api/reactor/INeutronCapture.java
@@ -1,0 +1,7 @@
+package mekanism.api.reactor;
+
+@Deprecated
+public interface INeutronCapture extends IReactorBlock
+{
+	public int absorbNeutrons(int neutrons);
+}

--- a/src/main/java/mekanism/api/reactor/IReactorBlock.java
+++ b/src/main/java/mekanism/api/reactor/IReactorBlock.java
@@ -1,0 +1,11 @@
+package mekanism.api.reactor;
+
+@Deprecated
+public interface IReactorBlock
+{
+	public boolean isFrame();
+
+	public void setReactor(IFusionReactor reactor);
+
+	public IFusionReactor getReactor();
+}

--- a/src/main/java/mekanism/common/capabilities/Capabilities.java
+++ b/src/main/java/mekanism/common/capabilities/Capabilities.java
@@ -36,6 +36,10 @@ public class Capabilities
     @CapabilityInject(IStrictEnergyOutputter.class)
     public static Capability<IStrictEnergyOutputter> ENERGY_OUTPUTTER_CAPABILITY = null;
 
+	@CapabilityInject(mekanism.api.energy.ICableOutputter.class)
+	@Deprecated //no longer in use.
+	public static Capability<mekanism.api.energy.ICableOutputter> CABLE_OUTPUTTER_CAPABILITY = null;
+
     @CapabilityInject(IConfigurable.class)
     public static Capability<IConfigurable> CONFIGURABLE_CAPABILITY = null;
 

--- a/src/main/java/mekanism/common/capabilities/DefaultCableOutputter.java
+++ b/src/main/java/mekanism/common/capabilities/DefaultCableOutputter.java
@@ -25,5 +25,21 @@ public class DefaultCableOutputter implements IStrictEnergyOutputter
     public static void register()
     {
         CapabilityManager.INSTANCE.register(IStrictEnergyOutputter.class, new NullStorage<>(), DefaultCableOutputter.class);
+        //empty backwards compat
+        DeprecatedCableOutputter.register();
+    }
+
+    @SuppressWarnings("deprecation")
+    public static class DeprecatedCableOutputter implements mekanism.api.energy.ICableOutputter{
+
+	    private static void register(){
+            CapabilityManager.INSTANCE.register(mekanism.api.energy.ICableOutputter.class, new NullStorage<>(), DeprecatedCableOutputter.class );
+        }
+
+        @Override
+        public boolean canOutputTo(EnumFacing side)
+        {
+            return false;
+        }
     }
 }


### PR DESCRIPTION
Marked as deprecated, should be excluded from the MDK zip.

Tested with the Flux Networks from #4540 and it loads fine.

The capability is a complete dud, but in the unlikely event anyone does use the field in `Capabilities` they likely won't check it's non-null, which could cause issues.