### PR TITLE
Performance improvements, pass 1

### DIFF
--- a/src/main/java/mekanism/common/base/IEnergyWrapper.java
+++ b/src/main/java/mekanism/common/base/IEnergyWrapper.java
@@ -25,8 +25,10 @@ import cofh.api.energy.IEnergyReceiver;
 public interface IEnergyWrapper extends IStrictEnergyStorage, IEnergyReceiver, IEnergyProvider, IEnergySink, IEnergySource, IEnergyStorage, IStrictEnergyAcceptor, IStrictEnergyOutputter, IInventory
 {
 	public EnumSet<EnumFacing> getOutputtingSides();
+	public boolean sideIsOutput(EnumFacing side);
 
 	public EnumSet<EnumFacing> getConsumingSides();
+	public boolean sideIsConsumer(EnumFacing side);
 
 	public double getMaxOutput();
 }

--- a/src/main/java/mekanism/common/integration/forgeenergy/ForgeEnergyIntegration.java
+++ b/src/main/java/mekanism/common/integration/forgeenergy/ForgeEnergyIntegration.java
@@ -44,13 +44,13 @@ public class ForgeEnergyIntegration implements IEnergyStorage
 	@Override
 	public boolean canExtract() 
 	{
-		return tileEntity.getOutputtingSides().contains(side);
+		return tileEntity.sideIsOutput(side);
 	}
 
 	@Override
 	public boolean canReceive() 
 	{
-		return tileEntity.getConsumingSides().contains(side);
+		return tileEntity.sideIsConsumer(side);
 	}
 	
 	public static int rfToForge(int rf)

--- a/src/main/java/mekanism/common/network/PacketConfigurationUpdate.java
+++ b/src/main/java/mekanism/common/network/PacketConfigurationUpdate.java
@@ -60,7 +60,7 @@ public class PacketConfigurationUpdate implements IMessageHandler<ConfigurationU
 						}
 						else if(message.clickType == 2)
 						{
-							((ISideConfiguration)tile).getConfig().getConfig(message.transmission)[message.configIndex.ordinal()] = 0;
+							((ISideConfiguration)tile).getConfig().getConfig(message.transmission).set(message.configIndex, (byte) 0);
 						}
 		
 						tile.markDirty();

--- a/src/main/java/mekanism/common/tile/TileEntityAdvancedBoundingBlock.java
+++ b/src/main/java/mekanism/common/tile/TileEntityAdvancedBoundingBlock.java
@@ -32,89 +32,97 @@ public class TileEntityAdvancedBoundingBlock extends TileEntityBoundingBlock imp
 	@Override
 	public boolean isEmpty()
 	{
-		if(getInv() == null)
+		IAdvancedBoundingBlock inv = getInv();
+		if(inv == null)
 		{
 			return true;
 		}
 		
-		return getInv().isEmpty();
+		return inv.isEmpty();
 	}
 	
 	@Override
 	public int getSizeInventory()
 	{
-		if(getInv() == null)
+		IAdvancedBoundingBlock inv = getInv();
+		if(inv == null)
 		{
 			return 0;
 		}
 
-		return getInv().getSizeInventory();
+		return inv.getSizeInventory();
 	}
 
 	@Override
 	public ItemStack getStackInSlot(int i)
 	{
-		if(getInv() == null)
+		IAdvancedBoundingBlock inv = getInv();
+		if(inv == null)
 		{
 			return ItemStack.EMPTY;
 		}
 
-		return getInv().getStackInSlot(i);
+		return inv.getStackInSlot(i);
 	}
 
 	@Override
 	public ItemStack decrStackSize(int i, int j)
 	{
-		if(getInv() == null)
+		IAdvancedBoundingBlock inv = getInv();
+		if(inv == null)
 		{
 			return ItemStack.EMPTY;
 		}
 
-		return getInv().decrStackSize(i, j);
+		return inv.decrStackSize(i, j);
 	}
 
 	@Override
 	public ItemStack removeStackFromSlot(int i)
 	{
-		if(getInv() == null)
+		IAdvancedBoundingBlock inv = getInv();
+		if(inv == null)
 		{
 			return ItemStack.EMPTY;
 		}
 
-		return getInv().removeStackFromSlot(i);
+		return inv.removeStackFromSlot(i);
 	}
 
 	@Override
 	public void setInventorySlotContents(int i, ItemStack itemstack)
 	{
-		if(getInv() == null)
+		IAdvancedBoundingBlock inv = getInv();
+		if(inv == null)
 		{
 			return;
 		}
 
-		getInv().setInventorySlotContents(i, itemstack);
+		inv.setInventorySlotContents(i, itemstack);
 	}
 
 	@Override
 	public String getName()
 	{
-		if(getInv() == null)
+		IAdvancedBoundingBlock inv = getInv();
+		if(inv == null)
 		{
 			return "null";
 		}
 
-		return getInv().getName();
+		return inv.getName();
 	}
 
 	@Override
 	public boolean hasCustomName()
 	{
-		if(getInv() == null)
+		IAdvancedBoundingBlock inv = getInv();
+		if(inv == null)
 		{
 			return false;
 		}
 
-		return getInv().hasCustomName();
+		return inv.hasCustomName();
 	}
 
 	@Override
@@ -126,56 +134,61 @@ public class TileEntityAdvancedBoundingBlock extends TileEntityBoundingBlock imp
 	@Override
 	public int getInventoryStackLimit()
 	{
-		if(getInv() == null)
+		IAdvancedBoundingBlock inv = getInv();
+		if(inv == null)
 		{
 			return 0;
 		}
 
-		return getInv().getInventoryStackLimit();
+		return inv.getInventoryStackLimit();
 	}
 
 	@Override
 	public boolean isUsableByPlayer(EntityPlayer entityplayer)
 	{
-		if(getInv() == null)
+		IAdvancedBoundingBlock inv = getInv();
+		if(inv == null)
 		{
 			return false;
 		}
 
-		return getInv().isUsableByPlayer(entityplayer);
+		return inv.isUsableByPlayer(entityplayer);
 	}
 
 	@Override
 	public void openInventory(EntityPlayer player)
 	{
-		if(getInv() == null)
+		IAdvancedBoundingBlock inv = getInv();
+		if(inv == null)
 		{
 			return;
 		}
 
-		getInv().openInventory(player);
+		inv.openInventory(player);
 	}
 
 	@Override
 	public void closeInventory(EntityPlayer player)
 	{
-		if(getInv() == null)
+		IAdvancedBoundingBlock inv = getInv();
+		if(inv == null)
 		{
 			return;
 		}
 
-		getInv().closeInventory(player);
+		inv.closeInventory(player);
 	}
 
 	@Override
 	public boolean isItemValidForSlot(int i, ItemStack itemstack)
 	{
-		if(getInv() == null)
+		IAdvancedBoundingBlock inv = getInv();
+		if(inv == null)
 		{
 			return false;
 		}
 
-		return getInv().canBoundInsert(getPos(), i, itemstack);
+		return inv.canBoundInsert(getPos(), i, itemstack);
 	}
 
 	@Override
@@ -202,12 +215,13 @@ public class TileEntityAdvancedBoundingBlock extends TileEntityBoundingBlock imp
 	@Override
 	public int[] getSlotsForFace(EnumFacing side)
 	{
-		if(getInv() == null)
+		IAdvancedBoundingBlock inv = getInv();
+		if(inv == null)
 		{
 			return InventoryUtils.EMPTY;
 		}
 
-		return getInv().getBoundSlots(getPos(), side);
+		return inv.getBoundSlots(getPos(), side);
 	}
 
 	@Override
@@ -219,137 +233,138 @@ public class TileEntityAdvancedBoundingBlock extends TileEntityBoundingBlock imp
 	@Override
 	public boolean canExtractItem(int i, ItemStack itemstack, EnumFacing side)
 	{
-		if(getInv() == null)
+		IAdvancedBoundingBlock inv = getInv();
+		if(inv == null)
 		{
 			return false;
 		}
 
-		return getInv().canBoundExtract(getPos(), i, itemstack, side);
+		return inv.canBoundExtract(getPos(), i, itemstack, side);
 	}
 
 	@Override
 	@Method(modid = "IC2")
 	public boolean acceptsEnergyFrom(IEnergyEmitter emitter, EnumFacing direction)
 	{
-		if(getInv() == null)
+		IAdvancedBoundingBlock inv = getInv();
+		if(inv == null)
 		{
 			return false;
 		}
 
-		return getInv().acceptsEnergyFrom(emitter, direction);
+		return inv.acceptsEnergyFrom(emitter, direction);
 	}
 
 	@Override
 	public int receiveEnergy(EnumFacing from, int maxReceive, boolean simulate)
 	{
-		if(getInv() == null || !canReceiveEnergy(from))
+		IAdvancedBoundingBlock inv = getInv();
+		if(inv == null || !canReceiveEnergy(from))
 		{
 			return 0;
 		}
 
-		return getInv().receiveEnergy(from, maxReceive, simulate);
+		return inv.receiveEnergy(from, maxReceive, simulate);
 	}
 
 	@Override
 	public int extractEnergy(EnumFacing from, int maxExtract, boolean simulate)
 	{
-		if(getInv() == null)
+		IAdvancedBoundingBlock inv = getInv();
+		if(inv == null)
 		{
 			return 0;
 		}
 
-		return getInv().extractEnergy(from, maxExtract, simulate);
+		return inv.extractEnergy(from, maxExtract, simulate);
 	}
 
 	@Override
 	public boolean canConnectEnergy(EnumFacing from)
 	{
-		if(getInv() == null)
-		{
-			return false;
-		}
-
 		return canReceiveEnergy(from);
 	}
 
 	@Override
 	public int getEnergyStored(EnumFacing from)
 	{
-		if(getInv() == null)
+		IAdvancedBoundingBlock inv = getInv();
+		if(inv == null)
 		{
 			return 0;
 		}
 
-		return getInv().getEnergyStored(from);
+		return inv.getEnergyStored(from);
 	}
 
 	@Override
 	public int getMaxEnergyStored(EnumFacing from)
 	{
-		if(getInv() == null)
+		IAdvancedBoundingBlock inv = getInv();
+		if(inv == null)
 		{
 			return 0;
 		}
 
-		return getInv().getMaxEnergyStored(from);
+		return inv.getMaxEnergyStored(from);
 	}
 
 	@Override
 	public double acceptEnergy(EnumFacing side, double amount, boolean simulate)
 	{
-		if(getInv() == null || !canReceiveEnergy(side))
+		IAdvancedBoundingBlock inv = getInv();
+		if(inv == null || !canReceiveEnergy(side))
 		{
 			return 0;
 		}
 
-		return getInv().acceptEnergy(side, amount, simulate);
+		return inv.acceptEnergy(side, amount, simulate);
 	}
 
 	@Override
 	public boolean canReceiveEnergy(EnumFacing side)
 	{
-		if(getInv() == null)
+		IAdvancedBoundingBlock inv = getInv();
+		if(inv == null)
 		{
 			return false;
 		}
 
-		return getInv().canBoundReceiveEnergy(getPos(), side);
+		return inv.canBoundReceiveEnergy(getPos(), side);
 	}
 
 	@Override
 	@Method(modid = "IC2")
 	public double getDemandedEnergy()
 	{
-		if(getInv() == null)
-		{
-			return 0;
-		}
-
-		return getInv().getDemandedEnergy();
+		IAdvancedBoundingBlock inv = getInv();
+		return inv == null ? 0 : inv.getDemandedEnergy();
 	}
 
 	@Override
 	@Method(modid = "IC2")
 	public double injectEnergy(EnumFacing directionFrom, double amount, double voltage)
 	{
-		if(getInv() == null || !canReceiveEnergy(directionFrom))
+		IAdvancedBoundingBlock inv = getInv();
+		if(inv == null || !canReceiveEnergy(directionFrom))
 		{
 			return amount;
 		}
 
-		return getInv().injectEnergy(directionFrom, amount, voltage);
+		return inv.injectEnergy(directionFrom, amount, voltage);
 	}
 
 	@Override
 	@Method(modid = "IC2")
 	public int getSinkTier()
 	{
-		if(getInv() == null)
+		IAdvancedBoundingBlock inv = getInv();
+		if(inv == null)
 		{
 			return 0;
 		}
 
-		return getInv().getSinkTier();
+		return inv.getSinkTier();
 	}
 
 	public IAdvancedBoundingBlock getInv()
@@ -367,7 +382,7 @@ public class TileEntityAdvancedBoundingBlock extends TileEntityBoundingBlock imp
 			return null;
 		}
 
-		return (IAdvancedBoundingBlock)new Coord4D(mainPos, world).getTileEntity(world);
+		return (IAdvancedBoundingBlock) tile;
 	}
 
 	@Override
@@ -375,9 +390,10 @@ public class TileEntityAdvancedBoundingBlock extends TileEntityBoundingBlock imp
 	{
 		super.onPower();
 
-		if(getInv() != null)
+		IAdvancedBoundingBlock inv = getInv();
+		if(inv != null)
 		{
-			getInv().onPower();
+			inv.onPower();
 		}
 	}
 
@@ -386,86 +402,104 @@ public class TileEntityAdvancedBoundingBlock extends TileEntityBoundingBlock imp
 	{
 		super.onNoPower();
 
-		if(getInv() != null)
+		IAdvancedBoundingBlock inv = getInv();
+		if(inv != null)
 		{
-			getInv().onNoPower();
+			inv.onNoPower();
 		}
 	}
 
 	@Override
 	public String[] getMethods()
 	{
-		if(getInv() == null)
+		IAdvancedBoundingBlock inv = getInv();
+		if(inv == null)
 		{
 			return new String[] {};
 		}
 
-		return getInv().getMethods();
+		return inv.getMethods();
 	}
 
 	@Override
 	public Object[] invoke(int method, Object[] arguments) throws Exception
 	{
-		if(getInv() == null)
+		IAdvancedBoundingBlock inv = getInv();
+		if(inv == null)
 		{
 			return new Object[] {};
 		}
 
-		return getInv().invoke(method, arguments);
+		return inv.invoke(method, arguments);
 	}
 
 	@Override
 	public NBTTagCompound getConfigurationData(NBTTagCompound nbtTags)
 	{
-		if(getInv() == null)
+		IAdvancedBoundingBlock inv = getInv();
+		if(inv == null)
 		{
 			return new NBTTagCompound();
 		}
 		
-		return getInv().getConfigurationData(nbtTags);
+		return inv.getConfigurationData(nbtTags);
 	}
 
 	@Override
 	public void setConfigurationData(NBTTagCompound nbtTags)
 	{
-		if(getInv() == null)
+		IAdvancedBoundingBlock inv = getInv();
+		if(inv == null)
 		{
 			return;
 		}
 		
-		getInv().setConfigurationData(nbtTags);
+		inv.setConfigurationData(nbtTags);
 	}
 
 	@Override
 	public String getDataType()
 	{
-		if(getInv() == null)
+		IAdvancedBoundingBlock inv = getInv();
+		if(inv == null)
 		{
 			return "null";
 		}
 		
-		return getInv().getDataType();
+		return inv.getDataType();
 	}
 
 	@Override
 	public boolean hasCapability(Capability<?> capability, EnumFacing facing)
 	{
-		if(getInv() == null || capability == Capabilities.TILE_NETWORK_CAPABILITY)
+		if (capability == Capabilities.TILE_NETWORK_CAPABILITY)
+		{
+			return super.hasCapability(capability, facing);
+		}
+
+		IAdvancedBoundingBlock inv = getInv();
+		if(inv == null)
 		{
 			return super.hasCapability(capability, facing);
 		}
 		
-		return getInv().hasCapability(capability, facing);
+		return inv.hasCapability(capability, facing);
 	}
 
 	@Override
 	public <T> T getCapability(Capability<T> capability, EnumFacing facing)
 	{
-		if(getInv() == null || capability == Capabilities.TILE_NETWORK_CAPABILITY)
+		if (capability == Capabilities.TILE_NETWORK_CAPABILITY)
+		{
+			return super.getCapability(capability, facing);
+		}
+
+		IAdvancedBoundingBlock inv = getInv();
+		if(inv == null)
 		{
 			return super.getCapability(capability, facing);
 		}
 		
-		return getInv().getCapability(capability, facing);
+		return inv.getCapability(capability, facing);
 	}
 }

--- a/src/main/java/mekanism/common/tile/TileEntityChargepad.java
+++ b/src/main/java/mekanism/common/tile/TileEntityChargepad.java
@@ -176,6 +176,11 @@ public class TileEntityChargepad extends TileEntityNoisyBlock
 	}
 
 	@Override
+	public boolean sideIsConsumer(EnumFacing side) {
+		return side == EnumFacing.DOWN || side == facing.getOpposite();
+	}
+
+	@Override
 	public boolean getActive()
 	{
 		return isActive;

--- a/src/main/java/mekanism/common/tile/TileEntityEnergyCube.java
+++ b/src/main/java/mekanism/common/tile/TileEntityEnergyCube.java
@@ -162,9 +162,19 @@ public class TileEntityEnergyCube extends TileEntityElectricBlock implements ICo
 	}
 
 	@Override
+	public boolean sideIsConsumer(EnumFacing side) {
+		return configComponent.hasSideForData(TransmissionType.ENERGY, facing, 1, side);
+	}
+
+	@Override
 	public EnumSet<EnumFacing> getOutputtingSides()
 	{
 		return configComponent.getSidesForData(TransmissionType.ENERGY, facing, 2);
+	}
+
+	@Override
+	public boolean sideIsOutput(EnumFacing side) {
+		return configComponent.hasSideForData(TransmissionType.ENERGY, facing, 2, side);
 	}
 
 	@Override

--- a/src/main/java/mekanism/common/tile/TileEntityFluidTank.java
+++ b/src/main/java/mekanism/common/tile/TileEntityFluidTank.java
@@ -245,10 +245,10 @@ public class TileEntityFluidTank extends TileEntityContainerBlock implements IAc
 	public int pushUp(FluidStack fluid, boolean doFill)
 	{
 		Coord4D up = Coord4D.get(this).offset(EnumFacing.UP);
-		
-		if(up.getTileEntity(world) instanceof TileEntityFluidTank)
+		TileEntity tileEntity = up.getTileEntity(world);
+		if(tileEntity instanceof TileEntityFluidTank)
 		{
-			IFluidHandler handler = CapabilityUtils.getCapability(up.getTileEntity(world), CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, EnumFacing.DOWN);
+			IFluidHandler handler = CapabilityUtils.getCapability(tileEntity, CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY, EnumFacing.DOWN);
 			
 			if(PipeUtils.canFill(handler, fluid))
 			{
@@ -565,7 +565,7 @@ public class TileEntityFluidTank extends TileEntityContainerBlock implements IAc
 	public boolean canFill(EnumFacing from, Fluid fluid)
 	{
 		TileEntity tile = world.getTileEntity(getPos().offset(EnumFacing.DOWN));
-		if(from == EnumFacing.DOWN && world != null && getPos() != null)
+		if(from == EnumFacing.DOWN && world != null)
 		{
 			if(isActive && !(tile instanceof TileEntityFluidTank))
 			{

--- a/src/main/java/mekanism/common/tile/TileEntityGasTank.java
+++ b/src/main/java/mekanism/common/tile/TileEntityGasTank.java
@@ -244,7 +244,7 @@ public class TileEntityGasTank extends TileEntityContainerBlock implements IGasH
 	@Override
 	public boolean canReceiveGas(EnumFacing side, Gas type)
 	{
-		if(configComponent.getSidesForData(TransmissionType.GAS, facing, 1).contains(side))
+		if(configComponent.hasSideForData(TransmissionType.GAS, facing, 1, side))
 		{
 			return gasTank.canReceive(type);
 		}

--- a/src/main/java/mekanism/common/tile/TileEntityInductionPort.java
+++ b/src/main/java/mekanism/common/tile/TileEntityInductionPort.java
@@ -442,13 +442,13 @@ public class TileEntityInductionPort extends TileEntityInductionCasing implement
 	@Override
 	public double acceptEnergy(EnumFacing side, double amount, boolean simulate)
 	{
-		if(!getConsumingSides().contains(side))
+		double toUse = Math.min(Math.min(getMaxInput(), getMaxEnergy()-getEnergy()), amount);
+
+		if(toUse < 0.0001 || (side != null && !sideIsConsumer(side)))
 		{
 			return 0;
 		}
 
-		double toUse = Math.min(Math.min(getMaxInput(), getMaxEnergy()-getEnergy()), amount);
-		
 		if(!simulate)
 		{
 			setEnergy(getEnergy() + toUse);
@@ -461,14 +461,18 @@ public class TileEntityInductionPort extends TileEntityInductionCasing implement
 	@Override
 	public double pullEnergy(EnumFacing side, double amount, boolean simulate)
 	{
-		if(!getOutputtingSides().contains(side))
+		double toGive = Math.min(getEnergy(), amount);
+
+		if(toGive < 0.0001 || (side != null && !sideIsOutput(side)))
 		{
 			return 0;
 		}
 		
-		double toGive = Math.min(getEnergy(), amount);
-		setEnergy(getEnergy() - toGive);
-		
+		if (!simulate)
+		{
+			setEnergy(getEnergy() - toGive);
+		}
+
 		return toGive;
 	}
 

--- a/src/main/java/mekanism/common/tile/TileEntityInductionPort.java
+++ b/src/main/java/mekanism/common/tile/TileEntityInductionPort.java
@@ -103,6 +103,15 @@ public class TileEntityInductionPort extends TileEntityInductionCasing implement
 	}
 
 	@Override
+	public boolean sideIsOutput(EnumFacing side) {
+		if (structure != null && mode)
+		{
+			return !structure.locations.contains(Coord4D.get(this).offset(side));
+		}
+		return false;
+	}
+
+	@Override
 	public EnumSet<EnumFacing> getConsumingSides()
 	{
 		if(structure != null && !mode)
@@ -112,7 +121,12 @@ public class TileEntityInductionPort extends TileEntityInductionCasing implement
 		
 		return EnumSet.noneOf(EnumFacing.class);
 	}
-	
+
+	@Override
+	public boolean sideIsConsumer(EnumFacing side) {
+		return (structure != null && !mode);
+	}
+
 	@Method(modid = "IC2")
 	public void register()
 	{
@@ -241,7 +255,7 @@ public class TileEntityInductionPort extends TileEntityInductionCasing implement
 	@Override
 	public int receiveEnergy(EnumFacing from, int maxReceive, boolean simulate)
 	{
-		if(getConsumingSides().contains(from))
+		if(sideIsConsumer(from))
 		{
 			double toAdd = (int)Math.min(Math.min(getMaxInput(), getMaxEnergy()-getEnergy()), maxReceive* general.FROM_RF);
 
@@ -260,7 +274,7 @@ public class TileEntityInductionPort extends TileEntityInductionCasing implement
 	@Override
 	public int extractEnergy(EnumFacing from, int maxExtract, boolean simulate)
 	{
-		if(getOutputtingSides().contains(from))
+		if(sideIsOutput(from))
 		{
 			double toSend = Math.min(getEnergy(), Math.min(getMaxOutput(), maxExtract*general.FROM_RF));
 
@@ -335,21 +349,21 @@ public class TileEntityInductionPort extends TileEntityInductionCasing implement
 	@Override
 	public boolean canOutputEnergy(EnumFacing side)
 	{
-		return getOutputtingSides().contains(side);
+		return sideIsOutput(side);
 	}
 
 	@Override
 	@Method(modid = "IC2")
 	public boolean acceptsEnergyFrom(IEnergyEmitter emitter, EnumFacing direction)
 	{
-		return getConsumingSides().contains(direction);
+		return sideIsConsumer(direction);
 	}
 
 	@Override
 	@Method(modid = "IC2")
 	public boolean emitsEnergyTo(IEnergyAcceptor receiver, EnumFacing direction)
 	{
-		return getOutputtingSides().contains(direction) && receiver instanceof IEnergyConductor;
+		return sideIsOutput(direction) && receiver instanceof IEnergyConductor;
 	}
 
 	@Override
@@ -390,7 +404,7 @@ public class TileEntityInductionPort extends TileEntityInductionCasing implement
 	@Override
 	public boolean canReceiveEnergy(EnumFacing side)
 	{
-		return getConsumingSides().contains(side);
+		return sideIsConsumer(side);
 	}
 
 	@Override
@@ -512,8 +526,8 @@ public class TileEntityInductionPort extends TileEntityInductionCasing implement
 				|| capability == Capabilities.ENERGY_OUTPUTTER_CAPABILITY
 				|| capability == Capabilities.TESLA_HOLDER_CAPABILITY
 				|| capability == Capabilities.CONFIGURABLE_CAPABILITY
-				|| (capability == Capabilities.TESLA_CONSUMER_CAPABILITY && getConsumingSides().contains(facing))
-				|| (capability == Capabilities.TESLA_PRODUCER_CAPABILITY && getOutputtingSides().contains(facing))
+				|| (capability == Capabilities.TESLA_CONSUMER_CAPABILITY && sideIsConsumer(facing))
+				|| (capability == Capabilities.TESLA_PRODUCER_CAPABILITY && sideIsOutput(facing))
 				|| capability == CapabilityEnergy.ENERGY
 				|| super.hasCapability(capability, facing);
 	}
@@ -531,8 +545,8 @@ public class TileEntityInductionPort extends TileEntityInductionCasing implement
 		}
 		
 		if(capability == Capabilities.TESLA_HOLDER_CAPABILITY
-				|| (capability == Capabilities.TESLA_CONSUMER_CAPABILITY && getConsumingSides().contains(facing))
-				|| (capability == Capabilities.TESLA_PRODUCER_CAPABILITY && getOutputtingSides().contains(facing)))
+				|| (capability == Capabilities.TESLA_CONSUMER_CAPABILITY && sideIsConsumer(facing))
+				|| (capability == Capabilities.TESLA_PRODUCER_CAPABILITY && sideIsOutput(facing)))
 		{
 			return (T)teslaManager.getWrapper(this, facing);
 		}

--- a/src/main/java/mekanism/common/tile/TileEntityLaser.java
+++ b/src/main/java/mekanism/common/tile/TileEntityLaser.java
@@ -123,7 +123,12 @@ public class TileEntityLaser extends TileEntityNoisyBlock implements IActiveStat
 	{
 		return EnumSet.of(facing.getOpposite());
 	}
-	
+
+	@Override
+	public boolean sideIsConsumer(EnumFacing side) {
+		return side == facing.getOpposite();
+	}
+
 	@Override
 	public void setActive(boolean active)
 	{

--- a/src/main/java/mekanism/common/tile/TileEntityLaserAmplifier.java
+++ b/src/main/java/mekanism/common/tile/TileEntityLaserAmplifier.java
@@ -196,6 +196,11 @@ public class TileEntityLaserAmplifier extends TileEntityContainerBlock implement
 	public double pullEnergy(EnumFacing side, double amount, boolean simulate)
 	{
 		double toGive = Math.min(getEnergy(), amount);
+
+		if (toGive < 0.0001)
+		{
+			return 0;
+		}
 		
 		if(!simulate)
 		{

--- a/src/main/java/mekanism/common/tile/TileEntityLogisticalSorter.java
+++ b/src/main/java/mekanism/common/tile/TileEntityLogisticalSorter.java
@@ -559,6 +559,11 @@ public class TileEntityLogisticalSorter extends TileEntityElectricBlock implemen
 	}
 
 	@Override
+	public boolean sideIsConsumer(EnumFacing side) {
+		return false;
+	}
+
+	@Override
 	public boolean canSetFacing(int facing)
 	{
 		return true;

--- a/src/main/java/mekanism/common/tile/TileEntityMetallurgicInfuser.java
+++ b/src/main/java/mekanism/common/tile/TileEntityMetallurgicInfuser.java
@@ -184,7 +184,7 @@ public class TileEntityMetallurgicInfuser extends TileEntityOperationalMachine i
 		
 		for(TransmissionType transmission : configComponent.transmissions)
 		{
-			factory.configComponent.setConfig(transmission, configComponent.getConfig(transmission));
+			factory.configComponent.setConfig(transmission, configComponent.getConfig(transmission).asByteArray());
 			factory.configComponent.setEjecting(transmission, configComponent.isEjecting(transmission));
 		}
 		

--- a/src/main/java/mekanism/common/tile/TileEntityQuantumEntangloporter.java
+++ b/src/main/java/mekanism/common/tile/TileEntityQuantumEntangloporter.java
@@ -373,9 +373,27 @@ public class TileEntityQuantumEntangloporter extends TileEntityElectricBlock imp
 	}
 
 	@Override
+	public boolean sideIsOutput(EnumFacing side) {
+		if (!hasFrequency())
+		{
+			return false;
+		}
+		return configComponent.hasSideForData(TransmissionType.ENERGY, facing, 2, side);
+	}
+
+	@Override
 	public EnumSet<EnumFacing> getConsumingSides()
 	{
 		return !hasFrequency() ? nothing : configComponent.getSidesForData(TransmissionType.ENERGY, facing, 1);
+	}
+
+	@Override
+	public boolean sideIsConsumer(EnumFacing side) {
+		if (!hasFrequency())
+		{
+			return false;
+		}
+		return configComponent.hasSideForData(TransmissionType.ENERGY, facing, 1, side);
 	}
 
 	@Override

--- a/src/main/java/mekanism/common/tile/TileEntityResistiveHeater.java
+++ b/src/main/java/mekanism/common/tile/TileEntityResistiveHeater.java
@@ -129,7 +129,12 @@ public class TileEntityResistiveHeater extends TileEntityNoisyBlock implements I
 	{
 		return EnumSet.of(MekanismUtils.getLeft(facing), MekanismUtils.getRight(facing));
 	}
-	
+
+	@Override
+	public boolean sideIsConsumer(EnumFacing side) {
+		return side == MekanismUtils.getLeft(facing) || side == MekanismUtils.getRight(facing);
+	}
+
 	@Override
 	public boolean canSetFacing(int side)
 	{

--- a/src/main/java/mekanism/common/tile/TileEntitySeismicVibrator.java
+++ b/src/main/java/mekanism/common/tile/TileEntitySeismicVibrator.java
@@ -214,6 +214,11 @@ public class TileEntitySeismicVibrator extends TileEntityElectricBlock implement
 	}
 
 	@Override
+	public boolean sideIsConsumer(EnumFacing side) {
+		return side == facing.getOpposite();
+	}
+
+	@Override
 	public void setControlType(RedstoneControl type)
 	{
 		controlType = type;

--- a/src/main/java/mekanism/common/tile/component/SideConfig.java
+++ b/src/main/java/mekanism/common/tile/component/SideConfig.java
@@ -1,0 +1,56 @@
+package mekanism.common.tile.component;
+
+import net.minecraft.util.EnumFacing;
+
+import java.util.Observable;
+import java.util.Observer;
+
+public class SideConfig {
+    private byte[] directions = new byte[EnumFacing.VALUES.length];
+    private Observable observable = new Observable();
+
+    public SideConfig()
+    {
+    }
+
+    public SideConfig(byte[] b) {
+        this(b[0], b[1], b[2], b[3], b[4], b[5]);
+        assert b.length == EnumFacing.VALUES.length;
+    }
+
+    public SideConfig(byte d, byte u, byte n, byte s, byte w, byte e)
+    {
+        setDirections(d, u, n, s, w, e);
+    }
+
+    public void setDirections(byte d, byte u, byte n, byte s, byte w, byte e) {
+        directions[0] = d;
+        directions[1] = u;
+        directions[2] = n;
+        directions[3] = s;
+        directions[4] = w;
+        directions[5] = e;
+        observable.notifyObservers(this);
+    }
+
+    public byte get(EnumFacing f) {
+        return directions[f.ordinal()];
+    }
+
+    public byte[] asByteArray() {
+        return directions;
+    }
+
+    public void set(EnumFacing f, byte value) {
+        directions[f.ordinal()] = value;
+        observable.notifyObservers(this);
+    }
+
+    public void addObserver(Observer o) {
+        observable.addObserver(o);
+    }
+
+    public void deleteObserver(Observer o) {
+        observable.deleteObserver(o);
+    }
+}

--- a/src/main/java/mekanism/common/tile/component/TileComponentConfig.java
+++ b/src/main/java/mekanism/common/tile/component/TileComponentConfig.java
@@ -25,12 +25,12 @@ public class TileComponentConfig implements ITileComponent
 	
 	public TileEntityContainerBlock tileEntity;
 	
-	public Map<Integer, byte[]> sideConfigs = new HashMap<Integer, byte[]>();
-	public Map<Integer, ArrayList<SideData>> sideOutputs = new HashMap<Integer, ArrayList<SideData>>();
-	public Map<Integer, Boolean> ejecting = new HashMap<Integer, Boolean>();
-	public Map<Integer, Boolean> canEject = new HashMap<Integer, Boolean>();
+	private Map<TransmissionType, SideConfig> sideConfigs = new HashMap<>();
+	private Map<TransmissionType, ArrayList<SideData>> sideOutputs = new HashMap<>();
+	private Map<TransmissionType, Boolean> ejecting = new HashMap<>();
+	private Map<TransmissionType, Boolean> canEject = new HashMap<>();
 	
-	public List<TransmissionType> transmissions = new ArrayList<TransmissionType>();
+	public List<TransmissionType> transmissions = new ArrayList<>();
 	
 	public TileComponentConfig(TileEntityContainerBlock tile, TransmissionType... types)
 	{
@@ -59,43 +59,48 @@ public class TileComponentConfig implements ITileComponent
 			transmissions.add(type);
 		}
 		
-		sideOutputs.put(type.ordinal(), new ArrayList<SideData>());
-		ejecting.put(type.ordinal(), false);
-		canEject.put(type.ordinal(), true);
+		sideOutputs.put(type, new ArrayList<>());
+		ejecting.put(type, false);
+		canEject.put(type, true);
 	}
-	
+
 	public EnumSet<EnumFacing> getSidesForData(TransmissionType type, EnumFacing facing, int dataIndex)
 	{
 		EnumSet<EnumFacing> ret = EnumSet.noneOf(EnumFacing.class);
+		SideConfig config = getConfig(type);
+		EnumFacing[] translatedFacings = MekanismUtils.getBaseOrientations(facing);
 		
-		for(EnumFacing f : EnumFacing.VALUES)
+		for(int i = 0; i < EnumFacing.VALUES.length; i++)
 		{
-			EnumFacing side = MekanismUtils.getBaseOrientation(f, facing);
-
-			if(getConfig(type)[side.ordinal()] == dataIndex)
+			if(config.get(translatedFacings[i]) == dataIndex)
 			{
-				ret.add(f);
+				ret.add(translatedFacings[i]);
 			}
 		}
 		
 		return ret;
 	}
+
+	public boolean hasSideForData(TransmissionType type, EnumFacing facing, int dataIndex, EnumFacing sideToTest)
+	{
+		return getConfig(type).get(sideToTest) == dataIndex;
+	}
 	
 	public void setCanEject(TransmissionType type, boolean eject)
 	{
-		canEject.put(type.ordinal(), eject);
+		canEject.put(type, eject);
 	}
 	
 	public boolean canEject(TransmissionType type)
 	{
-		return canEject.get(type.ordinal());
+		return canEject.get(type);
 	}
 	
 	public void fillConfig(TransmissionType type, int data)
 	{
 		byte sideData = (byte)data;
 		
-		setConfig(type, new byte[] {sideData, sideData, sideData, sideData, sideData, sideData});
+		setConfig(type, sideData, sideData, sideData, sideData, sideData, sideData);
 	}
 	
 	public void setIOConfig(TransmissionType type)
@@ -115,25 +120,31 @@ public class TileComponentConfig implements ITileComponent
 		fillConfig(type, 1);
 		setCanEject(type, false);
 	}
-	
+
 	public void setConfig(TransmissionType type, byte[] config)
 	{
-		sideConfigs.put(type.ordinal(), config);
+		assert config.length == EnumFacing.VALUES.length;
+		setConfig(type, config[0], config[1], config[2], config[3], config[4], config[5]);
+	}
+
+	public void setConfig(TransmissionType type, byte d, byte u, byte n, byte s, byte w, byte e)
+	{
+		sideConfigs.put(type, new SideConfig(d, u, n, s, w, e));
 	}
 	
 	public void addOutput(TransmissionType type, SideData data)
 	{
-		sideOutputs.get(type.ordinal()).add(data);
+		sideOutputs.get(type).add(data);
 	}
 	
 	public ArrayList<SideData> getOutputs(TransmissionType type)
 	{
-		return sideOutputs.get(type.ordinal());
+		return sideOutputs.get(type);
 	}
 	
-	public byte[] getConfig(TransmissionType type)
+	public SideConfig getConfig(TransmissionType type)
 	{
-		return sideConfigs.get(type.ordinal());
+		return sideConfigs.get(type);
 	}
 	
 	public SideData getOutput(TransmissionType type, EnumFacing side, EnumFacing facing)
@@ -152,8 +163,9 @@ public class TileComponentConfig implements ITileComponent
 		{
 			return EMPTY;
 		}
-		
-		int index = getConfig(type)[side.ordinal()];
+
+		SideConfig sideConfig = getConfig(type);
+		int index = sideConfig.get(side);
 		
 		if(index == -1)
 		{
@@ -161,7 +173,8 @@ public class TileComponentConfig implements ITileComponent
 		}
 		else if(index > getOutputs(type).size()-1)
 		{
-			index = getConfig(type)[side.ordinal()] = 0;
+			sideConfig.set(side, (byte) 0);
+			index = 0;
 		}
 		
 		return getOutputs(type).get(index);
@@ -184,8 +197,8 @@ public class TileComponentConfig implements ITileComponent
 			{
 				if(nbtTags.getByteArray("config" + type.ordinal()).length > 0)
 				{
-					sideConfigs.put(type.ordinal(), nbtTags.getByteArray("config" + type.ordinal()));
-					ejecting.put(type.ordinal(), nbtTags.getBoolean("ejecting" + type.ordinal()));
+					sideConfigs.put(type, new SideConfig(nbtTags.getByteArray("config" + type.ordinal())));
+					ejecting.put(type, nbtTags.getBoolean("ejecting" + type.ordinal()));
 				}
 			}
 		}
@@ -207,9 +220,9 @@ public class TileComponentConfig implements ITileComponent
 		{
 			byte[] array = new byte[6];
 			dataStream.readBytes(array);
-			
-			sideConfigs.put(type.ordinal(), array);
-			ejecting.put(type.ordinal(), dataStream.readBoolean());
+
+			sideConfigs.put(type, new SideConfig(array));
+			ejecting.put(type, dataStream.readBoolean());
 		}
 	}
 
@@ -218,8 +231,8 @@ public class TileComponentConfig implements ITileComponent
 	{
 		for(TransmissionType type : transmissions)
 		{
-			nbtTags.setByteArray("config" + type.ordinal(), sideConfigs.get(type.ordinal()));
-			nbtTags.setBoolean("ejecting" + type.ordinal(), ejecting.get(type.ordinal()));
+			nbtTags.setByteArray("config" + type.ordinal(), sideConfigs.get(type).asByteArray());
+			nbtTags.setBoolean("ejecting" + type.ordinal(), ejecting.get(type));
 		}
 		
 		nbtTags.setBoolean("sideDataStored", true);
@@ -237,8 +250,8 @@ public class TileComponentConfig implements ITileComponent
 		
 		for(TransmissionType type : transmissions)
 		{
-			data.add(sideConfigs.get(type.ordinal()));
-			data.add(ejecting.get(type.ordinal()));
+			data.add(sideConfigs.get(type).asByteArray());
+			data.add(ejecting.get(type));
 		}
 	}
 	
@@ -247,12 +260,12 @@ public class TileComponentConfig implements ITileComponent
 	
 	public boolean isEjecting(TransmissionType type)
 	{
-		return ejecting.get(type.ordinal());
+		return ejecting.get(type);
 	}
 
 	public void setEjecting(TransmissionType type, boolean eject)
 	{
-		ejecting.put(type.ordinal(), eject);
+		ejecting.put(type, eject);
 		MekanismUtils.saveChunk(tileEntity);
 	}
 }

--- a/src/main/java/mekanism/common/tile/component/TileComponentEjector.java
+++ b/src/main/java/mekanism/common/tile/component/TileComponentEjector.java
@@ -153,13 +153,18 @@ public class TileComponentEjector implements ITileComponent
 		List<EnumFacing> outputSides = new ArrayList<EnumFacing>();
 		ISideConfiguration configurable = (ISideConfiguration)tileEntity;
 
-		for(int i = 0; i < configurable.getConfig().getConfig(type).length; i++)
+		SideConfig sideConfig = configurable.getConfig().getConfig(type);
+		ArrayList<SideData> outputs = configurable.getConfig().getOutputs(type);
+
+		EnumFacing[] facings = MekanismUtils.getBaseOrientations(tileEntity.facing);
+
+		for(int i = 0; i < EnumFacing.VALUES.length; i++)
 		{
-			EnumFacing side = MekanismUtils.getBaseOrientation(EnumFacing.getFront(i), tileEntity.facing);
-			
-			if(configurable.getConfig().getConfig(type)[side.ordinal()] == configurable.getConfig().getOutputs(type).indexOf(data))
+			EnumFacing side = facings[i];
+
+			if(sideConfig.get(side) == outputs.indexOf(data))
 			{
-				outputSides.add(EnumFacing.getFront(i));
+				outputSides.add(EnumFacing.VALUES[i]);
 			}
 		}
 		

--- a/src/main/java/mekanism/common/tile/prefab/TileEntityAdvancedElectricMachine.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityAdvancedElectricMachine.java
@@ -60,10 +60,10 @@ public abstract class TileEntityAdvancedElectricMachine<RECIPE extends AdvancedM
 	 *
 	 * @param soundPath - location of the sound effect
 	 * @param name - full name of this machine
-	 * @param perTick - how much energy this machine uses per tick.
-	 * @param secondaryPerTick - how much secondary energy (fuel) this machine uses per tick.
-	 * @param ticksRequired - how many ticks it takes to smelt an item.
 	 * @param maxEnergy - maximum amount of energy this machine can hold.
+	 * @param baseEnergyUsage - how much energy this machine uses per tick.
+	 * @param ticksRequired - how many ticks it takes to smelt an item.
+	 * @param secondaryPerTick - how much secondary energy (fuel) this machine uses per tick.
 	 */
 	public TileEntityAdvancedElectricMachine(String soundPath, String name, double maxEnergy, double baseEnergyUsage, int ticksRequired, int secondaryPerTick)
 	{
@@ -141,7 +141,7 @@ public abstract class TileEntityAdvancedElectricMachine<RECIPE extends AdvancedM
 		
 		for(TransmissionType transmission : configComponent.transmissions)
 		{
-			factory.configComponent.setConfig(transmission, configComponent.getConfig(transmission));
+			factory.configComponent.setConfig(transmission, configComponent.getConfig(transmission).asByteArray());
 			factory.configComponent.setEjecting(transmission, configComponent.isEjecting(transmission));
 		}
 		

--- a/src/main/java/mekanism/common/tile/prefab/TileEntityBasicMachine.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityBasicMachine.java
@@ -30,10 +30,8 @@ public abstract class TileEntityBasicMachine<INPUT extends MachineInput<INPUT>, 
 	 * The foundation of all machines - a simple tile entity with a facing, active state, initialized state, sound effect, and animated texture.
 	 * @param soundPath - location of the sound effect
 	 * @param name - full name of this machine
-	 * @param location - GUI texture path of this machine
-	 * @param perTick - the energy this machine consumes every tick in it's active state
-	 * @param baseTicksRequired - how many ticks it takes to run a cycle
 	 * @param maxEnergy - how much energy this machine can store
+	 * @param baseTicksRequired - how many ticks it takes to run a cycle
 	 */
 	public TileEntityBasicMachine(String soundPath, String name, double maxEnergy, double baseEnergyUsage, int upgradeSlot, int baseTicksRequired, ResourceLocation location)
 	{
@@ -46,6 +44,11 @@ public abstract class TileEntityBasicMachine<INPUT extends MachineInput<INPUT>, 
 	public EnumSet<EnumFacing> getConsumingSides()
 	{
 		return configComponent.getSidesForData(TransmissionType.ENERGY, facing, 1);
+	}
+
+	@Override
+	public boolean sideIsConsumer(EnumFacing side) {
+		return configComponent.hasSideForData(TransmissionType.ENERGY, facing, 1, side);
 	}
 
 	@Override

--- a/src/main/java/mekanism/common/tile/prefab/TileEntityElectricBlock.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityElectricBlock.java
@@ -108,9 +108,19 @@ public abstract class TileEntityElectricBlock extends TileEntityContainerBlock i
 	}
 
 	@Override
+	public boolean sideIsOutput(EnumFacing side) {
+		return false;
+	}
+
+	@Override
 	public EnumSet<EnumFacing> getConsumingSides()
 	{
 		return EnumSet.allOf(EnumFacing.class);
+	}
+
+	@Override
+	public boolean sideIsConsumer(EnumFacing side) {
+		return true;
 	}
 
 	@Override
@@ -235,7 +245,7 @@ public abstract class TileEntityElectricBlock extends TileEntityContainerBlock i
 	@Override
 	public boolean canConnectEnergy(EnumFacing from)
 	{
-		return getConsumingSides().contains(from) || getOutputtingSides().contains(from);
+		return sideIsConsumer(from) || sideIsOutput(from);
 	}
 
 	@Override
@@ -283,27 +293,27 @@ public abstract class TileEntityElectricBlock extends TileEntityContainerBlock i
 	@Method(modid = "IC2")
 	public boolean isTeleporterCompatible(EnumFacing side)
 	{
-		return getOutputtingSides().contains(side);
+		return sideIsOutput(side);
 	}
 
 	@Override
 	public boolean canOutputEnergy(EnumFacing side)
 	{
-		return getOutputtingSides().contains(side);
+		return sideIsOutput(side);
 	}
 
 	@Override
 	@Method(modid = "IC2")
 	public boolean acceptsEnergyFrom(IEnergyEmitter emitter, EnumFacing direction)
 	{
-		return getConsumingSides().contains(direction);
+		return sideIsConsumer(direction);
 	}
 
 	@Override
 	@Method(modid = "IC2")
 	public boolean emitsEnergyTo(IEnergyAcceptor receiver, EnumFacing direction)
 	{
-		return getOutputtingSides().contains(direction) && receiver instanceof IEnergyConductor;
+		return sideIsOutput(direction) && receiver instanceof IEnergyConductor;
 	}
 
 	@Override
@@ -344,7 +354,7 @@ public abstract class TileEntityElectricBlock extends TileEntityContainerBlock i
 	@Override
 	public boolean canReceiveEnergy(EnumFacing side)
 	{
-		return getConsumingSides().contains(side);
+		return sideIsConsumer(side);
 	}
 
 	@Override
@@ -418,8 +428,8 @@ public abstract class TileEntityElectricBlock extends TileEntityContainerBlock i
 				|| capability == Capabilities.ENERGY_ACCEPTOR_CAPABILITY
 				|| capability == Capabilities.ENERGY_OUTPUTTER_CAPABILITY
 				|| capability == Capabilities.TESLA_HOLDER_CAPABILITY
-				|| (capability == Capabilities.TESLA_CONSUMER_CAPABILITY && getConsumingSides().contains(facing))
-				|| (capability == Capabilities.TESLA_PRODUCER_CAPABILITY && getOutputtingSides().contains(facing))
+				|| (capability == Capabilities.TESLA_CONSUMER_CAPABILITY && sideIsConsumer(facing))
+				|| (capability == Capabilities.TESLA_PRODUCER_CAPABILITY && sideIsOutput(facing))
 				|| capability == CapabilityEnergy.ENERGY
 				|| super.hasCapability(capability, facing);
 	}
@@ -437,8 +447,8 @@ public abstract class TileEntityElectricBlock extends TileEntityContainerBlock i
 		}
 		
 		if(capability == Capabilities.TESLA_HOLDER_CAPABILITY
-				|| (capability == Capabilities.TESLA_CONSUMER_CAPABILITY && getConsumingSides().contains(facing))
-				|| (capability == Capabilities.TESLA_PRODUCER_CAPABILITY && getOutputtingSides().contains(facing)))
+				|| (capability == Capabilities.TESLA_CONSUMER_CAPABILITY && sideIsConsumer(facing))
+				|| (capability == Capabilities.TESLA_PRODUCER_CAPABILITY && sideIsOutput(facing)))
 		{
 			return (T)teslaManager.getWrapper(this, facing);
 		}

--- a/src/main/java/mekanism/common/tile/prefab/TileEntityElectricBlock.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityElectricBlock.java
@@ -388,12 +388,12 @@ public abstract class TileEntityElectricBlock extends TileEntityContainerBlock i
 	@Override
 	public double acceptEnergy(EnumFacing side, double amount, boolean simulate)
 	{
-		if(!(getConsumingSides().contains(side) || side == null))
+		double toUse = Math.min(getMaxEnergy()-getEnergy(), amount);
+
+		if(toUse < 0.0001 || (side != null && !sideIsConsumer(side)))
 		{
 			return 0;
 		}
-
-		double toUse = Math.min(getMaxEnergy()-getEnergy(), amount);
 		
 		if(!simulate)
 		{
@@ -406,12 +406,12 @@ public abstract class TileEntityElectricBlock extends TileEntityContainerBlock i
 	@Override
 	public double pullEnergy(EnumFacing side, double amount, boolean simulate)
 	{
-		if(!(getOutputtingSides().contains(side) || side == null))
+		double toGive = Math.min(getEnergy(), amount);
+
+		if(toGive < 0.0001 || (side != null && !sideIsOutput(side)))
 		{
 			return 0;
 		}
-		
-		double toGive = Math.min(getEnergy(), amount);
 		
 		if(!simulate)
 		{

--- a/src/main/java/mekanism/common/tile/prefab/TileEntityElectricMachine.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityElectricMachine.java
@@ -101,7 +101,7 @@ public abstract class TileEntityElectricMachine<RECIPE extends BasicMachineRecip
 		
 		for(TransmissionType transmission : configComponent.transmissions)
 		{
-			factory.configComponent.setConfig(transmission, configComponent.getConfig(transmission));
+			factory.configComponent.setConfig(transmission, configComponent.getConfig(transmission).asByteArray());
 			factory.configComponent.setEjecting(transmission, configComponent.isEjecting(transmission));
 		}
 

--- a/src/main/java/mekanism/common/tile/transmitter/TileEntityUniversalCable.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntityUniversalCable.java
@@ -287,13 +287,13 @@ public class TileEntityUniversalCable extends TileEntityTransmitter<EnergyAccept
 	@Override
 	public double acceptEnergy(EnumFacing side, double amount, boolean simulate)
 	{
-		if(!canReceiveEnergy(side))
+		double toUse = Math.min(getMaxEnergy() - getEnergy(), amount);
+
+		if(toUse < 0.0001 || (side != null && !canReceiveEnergy(side)))
 		{
 			return 0;
 		}
 
-		double toUse = Math.min(getMaxEnergy() - getEnergy(), amount);
-		
 		if(!simulate)
 		{
 			setEnergy(getEnergy() + toUse);

--- a/src/main/java/mekanism/generators/common/tile/TileEntityAdvancedSolarGenerator.java
+++ b/src/main/java/mekanism/generators/common/tile/TileEntityAdvancedSolarGenerator.java
@@ -26,6 +26,11 @@ public class TileEntityAdvancedSolarGenerator extends TileEntitySolarGenerator i
 	}
 
 	@Override
+	public boolean sideIsOutput(EnumFacing side) {
+		return side == facing;
+	}
+
+	@Override
 	public void onPlace()
 	{
 		Coord4D current = Coord4D.get(this);

--- a/src/main/java/mekanism/generators/common/tile/TileEntityGenerator.java
+++ b/src/main/java/mekanism/generators/common/tile/TileEntityGenerator.java
@@ -123,9 +123,19 @@ public abstract class TileEntityGenerator extends TileEntityNoisyBlock implement
 	}
 
 	@Override
+	public boolean sideIsConsumer(EnumFacing side) {
+		return false;
+	}
+
+	@Override
 	public EnumSet<EnumFacing> getOutputtingSides()
 	{
 		return EnumSet.of(facing);
+	}
+
+	@Override
+	public boolean sideIsOutput(EnumFacing side) {
+		return side == facing;
 	}
 
 	/**

--- a/src/main/java/mekanism/generators/common/tile/TileEntitySolarGenerator.java
+++ b/src/main/java/mekanism/generators/common/tile/TileEntitySolarGenerator.java
@@ -195,6 +195,11 @@ public class TileEntitySolarGenerator extends TileEntityGenerator
 	}
 
 	@Override
+	public boolean sideIsOutput(EnumFacing side) {
+		return side == EnumFacing.DOWN;
+	}
+
+	@Override
 	public boolean renderUpdate()
 	{
 		return false;

--- a/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorBlock.java
+++ b/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorBlock.java
@@ -83,11 +83,21 @@ public abstract class TileEntityReactorBlock extends TileEntityElectricBlock
 	}
 
 	@Override
+	public boolean sideIsOutput(EnumFacing side) {
+		return false;
+	}
+
+	@Override
 	public EnumSet<EnumFacing> getConsumingSides()
 	{
 		return EnumSet.noneOf(EnumFacing.class);
 	}
-	
+
+	@Override
+	public boolean sideIsConsumer(EnumFacing side) {
+		return false;
+	}
+
 	@Override
 	public void onChunkUnload()
 	{

--- a/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorPort.java
+++ b/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorPort.java
@@ -291,9 +291,19 @@ public class TileEntityReactorPort extends TileEntityReactorBlock implements IFl
 	}
 
 	@Override
+	public boolean sideIsOutput(EnumFacing side) {
+		return true;
+	}
+
+	@Override
 	public EnumSet<EnumFacing> getConsumingSides()
 	{
 		return EnumSet.noneOf(EnumFacing.class);
+	}
+
+	@Override
+	public boolean sideIsConsumer(EnumFacing side) {
+		return false;
 	}
 
 	@Override

--- a/src/main/java/mekanism/generators/common/tile/turbine/TileEntityTurbineValve.java
+++ b/src/main/java/mekanism/generators/common/tile/turbine/TileEntityTurbineValve.java
@@ -360,12 +360,12 @@ public class TileEntityTurbineValve extends TileEntityTurbineCasing implements I
 	@Override
 	public double pullEnergy(EnumFacing side, double amount, boolean simulate)
 	{
-		if(!getOutputtingSides().contains(side))
+		double toGive = Math.min(getEnergy(), amount);
+
+		if(toGive < 0.0001 || (side != null && !sideIsOutput(side)))
 		{
 			return 0;
 		}
-		
-		double toGive = Math.min(getEnergy(), amount);
 		
 		if(!simulate)
 		{

--- a/src/main/java/mekanism/generators/common/tile/turbine/TileEntityTurbineValve.java
+++ b/src/main/java/mekanism/generators/common/tile/turbine/TileEntityTurbineValve.java
@@ -77,7 +77,7 @@ public class TileEntityTurbineValve extends TileEntityTurbineCasing implements I
 	{
 		if(structure != null)
 		{
-			EnumSet set = EnumSet.allOf(EnumFacing.class);
+			EnumSet<EnumFacing> set = EnumSet.allOf(EnumFacing.class);
 			
 			for(EnumFacing side : EnumFacing.VALUES)
 			{
@@ -94,9 +94,23 @@ public class TileEntityTurbineValve extends TileEntityTurbineCasing implements I
 	}
 
 	@Override
+	public boolean sideIsOutput(EnumFacing side) {
+		if (structure != null)
+		{
+			return !structure.locations.contains(Coord4D.get(this).offset(side));
+		}
+		return false;
+	}
+
+	@Override
 	public EnumSet<EnumFacing> getConsumingSides()
 	{
 		return EnumSet.noneOf(EnumFacing.class);
+	}
+
+	@Override
+	public boolean sideIsConsumer(EnumFacing side) {
+		return false;
 	}
 	
 	@Method(modid = "IC2")
@@ -183,7 +197,7 @@ public class TileEntityTurbineValve extends TileEntityTurbineCasing implements I
 	@Override
 	public int extractEnergy(EnumFacing from, int maxExtract, boolean simulate)
 	{
-		if(getOutputtingSides().contains(from))
+		if(sideIsOutput(from))
 		{
 			double toSend = Math.min(getEnergy(), Math.min(getMaxOutput(), maxExtract*general.FROM_RF));
 
@@ -254,7 +268,7 @@ public class TileEntityTurbineValve extends TileEntityTurbineCasing implements I
 	@Override
 	public boolean canOutputEnergy(EnumFacing side)
 	{
-		return getOutputtingSides().contains(side);
+		return sideIsOutput(side);
 	}
 
 	@Override
@@ -268,7 +282,7 @@ public class TileEntityTurbineValve extends TileEntityTurbineCasing implements I
 	@Method(modid = "IC2")
 	public boolean emitsEnergyTo(IEnergyAcceptor receiver, EnumFacing direction)
 	{
-		return getOutputtingSides().contains(direction) && receiver instanceof IEnergyConductor;
+		return sideIsOutput(direction) && receiver instanceof IEnergyConductor;
 	}
 
 	@Override
@@ -473,7 +487,7 @@ public class TileEntityTurbineValve extends TileEntityTurbineCasing implements I
 					|| capability == Capabilities.ENERGY_STORAGE_CAPABILITY
 					|| capability == Capabilities.ENERGY_OUTPUTTER_CAPABILITY
 					|| capability == Capabilities.TESLA_HOLDER_CAPABILITY
-					|| (capability == Capabilities.TESLA_PRODUCER_CAPABILITY && getOutputtingSides().contains(facing))
+					|| (capability == Capabilities.TESLA_PRODUCER_CAPABILITY && sideIsOutput(facing))
 					|| capability == CapabilityEnergy.ENERGY)
 			{
 				return true;
@@ -502,7 +516,7 @@ public class TileEntityTurbineValve extends TileEntityTurbineCasing implements I
 			}
 			
 			if(capability == Capabilities.TESLA_HOLDER_CAPABILITY
-					|| (capability == Capabilities.TESLA_PRODUCER_CAPABILITY && getOutputtingSides().contains(facing)))
+					|| (capability == Capabilities.TESLA_PRODUCER_CAPABILITY && sideIsOutput(facing)))
 			{
 				return (T)teslaManager.getWrapper(this, facing);
 			}


### PR DESCRIPTION
My "All The Mods 2" server was being very slow. A user made a 5x ore processing flow and used Thermal Dynamics pipes for all the energy/fluid/item transfers, since the Mekanism pipes are currently really broken (#4507 and another issue where you have to place each pipe piece twice). The server's TPS was having severe issues, I profiled to see what's going on. Methods like "receiveEnergy" and "fill" were taking the vast majority of the time. So I dug in.

The result of today's investigation is these commits. I drastically increased the performance of these methods. For example receiveEnergy was not accounting for if we were already full of energy. It was always checking if the side was valid and marking the chunk dirty. You can look at each commit for its improvements.

The observer thing is something I haven't followed through with yet. My general thinking is like this: getConfig seems to be a bit slow (according to the profiler), and for these purposes it stores which sides are set to input, output, etc. That's something that the user generally changes shortly after placing the machine, and then doesn't touch again. So most of the effort of going and getting the config is wasted; we should be able to pretty aggressively cache which side is which. I figured if we add an observable and then trigger it when a side data is changed, then we can cache/memoize some methods and just update the cached values when the observer triggers an event.