### PR TITLE
Fix issue with side configuration not respecting block orientation

### DIFF
--- a/src/main/java/mekanism/common/tile/TileEntityFactory.java
+++ b/src/main/java/mekanism/common/tile/TileEntityFactory.java
@@ -394,6 +394,12 @@ public class TileEntityFactory extends TileEntityMachine implements IComputerInt
 	{
 		return configComponent.getSidesForData(TransmissionType.ENERGY, facing, 1);
 	}
+	
+	@Override
+	public boolean sideIsConsumer(EnumFacing side)
+	{
+		return configComponent.hasSideForData(TransmissionType.ENERGY, facing, 1, side);
+	}
 
 	public void sortInventory()
 	{

--- a/src/main/java/mekanism/common/tile/component/TileComponentConfig.java
+++ b/src/main/java/mekanism/common/tile/component/TileComponentConfig.java
@@ -70,11 +70,11 @@ public class TileComponentConfig implements ITileComponent
 		SideConfig config = getConfig(type);
 		EnumFacing[] translatedFacings = MekanismUtils.getBaseOrientations(facing);
 		
-		for(int i = 0; i < EnumFacing.VALUES.length; i++)
+		for(EnumFacing sideToCheck : EnumFacing.values())
 		{
-			if(config.get(translatedFacings[i]) == dataIndex)
+			if(config.get(translatedFacings[sideToCheck.ordinal()]) == dataIndex)
 			{
-				ret.add(translatedFacings[i]);
+				ret.add(sideToCheck);
 			}
 		}
 		

--- a/src/main/java/mekanism/common/tile/component/TileComponentConfig.java
+++ b/src/main/java/mekanism/common/tile/component/TileComponentConfig.java
@@ -83,7 +83,8 @@ public class TileComponentConfig implements ITileComponent
 
 	public boolean hasSideForData(TransmissionType type, EnumFacing facing, int dataIndex, EnumFacing sideToTest)
 	{
-		return getConfig(type).get(sideToTest) == dataIndex;
+		EnumFacing[] translatedFacings = MekanismUtils.getBaseOrientations(facing);
+		return getConfig(type).get(translatedFacings[sideToTest.ordinal()]) == dataIndex;
 	}
 	
 	public void setCanEject(TransmissionType type, boolean eject)


### PR DESCRIPTION
Fixes #4560 

I also noticed during my investigation that `IEnergyWrapper#getConsumingSides()` is no longer used anywhere in the project and `getOutputtingSides()` is only called in `CableUtils#emit(IEnergyWrapper)` so some code cleanup may be needed