### PR TITLE
[1.12] Fix bug in Pos3D due to mappings update

### DIFF
--- a/src/main/java/mekanism/api/Pos3D.java
+++ b/src/main/java/mekanism/api/Pos3D.java
@@ -137,7 +137,7 @@ public class Pos3D extends Vec3d
 	 */
 	public Pos3D translate(double x, double y, double z)
 	{
-		return new Pos3D(x + x, y + y, z + z);
+		return new Pos3D(this.x + x, this.y + y, this.z + z);
 	}
 
 	/**


### PR DESCRIPTION
https://github.com/aidancbrady/Mekanism/blob/1.12/src/main/java/mekanism/api/Pos3D.java#L140
The mappings update caused Pos3D.translate(double, double, double) to return bogus values.

The commit in which the mappings were updated is a13ce7910dff40578174b1f5a395ef72dea4f88f
@thommy101 probably forgot to add "this." because the previous fieldnames didn't need them.

This causes bugs down the line like the Laser not firing due to it thinking it's firing from x: 1 y: 1 z: 1.