### PR TITLE
Entangleporter Improvements

### DIFF
--- a/src/main/java/mekanism/client/gui/GuiQuantumEntangloporter.java
+++ b/src/main/java/mekanism/client/gui/GuiQuantumEntangloporter.java
@@ -9,6 +9,7 @@ import mekanism.api.EnumColor;
 import mekanism.client.gui.element.GuiScrollList;
 import mekanism.client.gui.element.GuiSideConfigurationTab;
 import mekanism.client.gui.element.GuiTransporterConfigTab;
+import mekanism.client.gui.element.GuiUpgradeTab;
 import mekanism.client.sound.SoundHandler;
 import mekanism.common.Mekanism;
 import mekanism.common.frequency.Frequency;
@@ -61,6 +62,7 @@ public class GuiQuantumEntangloporter extends GuiMekanism
 		guiElements.add(scrollList = new GuiScrollList(this, resource, 28, 37, 120, 4));
 		guiElements.add(new GuiSideConfigurationTab(this, tileEntity, MekanismUtils.getResource(ResourceType.GUI, "GuiTeleporter.png")));
 		guiElements.add(new GuiTransporterConfigTab(this, 34, tileEntity, MekanismUtils.getResource(ResourceType.GUI, "GuiTeleporter.png")));
+		guiElements.add(new GuiUpgradeTab(this, tileEntity, resource));
 		
 		if(tileEntity.frequency != null)
 		{

--- a/src/main/java/mekanism/common/block/BlockMachine.java
+++ b/src/main/java/mekanism/common/block/BlockMachine.java
@@ -19,13 +19,12 @@ import mekanism.common.base.ISustainedInventory;
 import mekanism.common.base.ISustainedTank;
 import mekanism.common.base.ITierItem;
 import mekanism.common.base.IUpgradeTile;
-import mekanism.common.block.states.BlockStateBasic;
-import mekanism.common.block.states.BlockStateBasic.BasicBlockType;
 import mekanism.common.block.states.BlockStateFacing;
 import mekanism.common.block.states.BlockStateMachine;
 import mekanism.common.block.states.BlockStateMachine.MachineBlock;
 import mekanism.common.block.states.BlockStateMachine.MachineType;
 import mekanism.common.config.MekanismConfig.client;
+import mekanism.common.content.entangloporter.InventoryFrequency;
 import mekanism.common.item.ItemBlockMachine;
 import mekanism.common.network.PacketLogisticalSorterGui.LogisticalSorterGuiMessage;
 import mekanism.common.network.PacketLogisticalSorterGui.SorterGuiPacket;
@@ -36,6 +35,7 @@ import mekanism.common.tile.TileEntityFluidTank;
 import mekanism.common.tile.TileEntityLaser;
 import mekanism.common.tile.TileEntityLaserAmplifier;
 import mekanism.common.tile.TileEntityLogisticalSorter;
+import mekanism.common.tile.TileEntityQuantumEntangloporter;
 import mekanism.common.tile.TileEntityMetallurgicInfuser;
 import mekanism.common.tile.TileEntityPersonalChest;
 import mekanism.common.tile.prefab.TileEntityBasicBlock;
@@ -78,7 +78,6 @@ import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.Explosion;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
-import net.minecraftforge.common.property.IExtendedBlockState;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidUtil;
 import net.minecraftforge.fluids.capability.IFluidHandlerItem;
@@ -914,6 +913,15 @@ public abstract class BlockMachine extends BlockContainer
 		{
 			IFactory factoryItem = (IFactory)itemStack.getItem();
 			factoryItem.setRecipeType(((TileEntityFactory)tileEntity).recipeType.ordinal(), itemStack);
+		}
+
+		if (tileEntity instanceof TileEntityQuantumEntangloporter)
+		{
+			InventoryFrequency frequency = ((TileEntityQuantumEntangloporter) tileEntity).frequency;
+			if (frequency != null)
+			{
+				ItemDataUtils.setCompound(itemStack, "entangleporter_frequency", frequency.getIdentity().serialise());
+			}
 		}
 
 		return itemStack;

--- a/src/main/java/mekanism/common/content/entangloporter/InventoryFrequency.java
+++ b/src/main/java/mekanism/common/content/entangloporter/InventoryFrequency.java
@@ -8,6 +8,7 @@ import java.util.UUID;
 import mekanism.api.gas.GasStack;
 import mekanism.api.gas.GasTank;
 import mekanism.common.PacketHandler;
+import mekanism.common.Tier;
 import mekanism.common.frequency.Frequency;
 import mekanism.common.util.InventoryUtils;
 import net.minecraft.item.ItemStack;
@@ -23,8 +24,10 @@ public class InventoryFrequency extends Frequency
 {
 	public static final String ENTANGLOPORTER = "Entangloporter";
 	
-	public static final double MAX_ENERGY = 1000000;
-	
+	public static final double MAX_ENERGY = Tier.EnergyCubeTier.ULTIMATE.output;
+	public static final int FLUID_TANK_SIZE = Tier.FluidTankTier.ULTIMATE.output;
+	public static final int GAS_TANK_SIZE = Tier.GasTankTier.ULTIMATE.output;
+
 	public double storedEnergy;
 	public FluidTank storedFluid;
 	public GasTank storedGas;
@@ -35,8 +38,8 @@ public class InventoryFrequency extends Frequency
 	{
 		super(n, uuid);
 		
-		storedFluid = new FluidTank(1000);
-		storedGas = new GasTank(1000);
+		storedFluid = new FluidTank(FLUID_TANK_SIZE);
+		storedGas = new GasTank(GAS_TANK_SIZE);
 	}
 	
 	public InventoryFrequency(NBTTagCompound nbtTags)
@@ -89,8 +92,8 @@ public class InventoryFrequency extends Frequency
 	{
 		super.read(nbtTags);
 		
-		storedFluid = new FluidTank(1000);
-		storedGas = new GasTank(1000);
+		storedFluid = new FluidTank(FLUID_TANK_SIZE);
+		storedGas = new GasTank(GAS_TANK_SIZE);
 		
 		storedEnergy = nbtTags.getDouble("storedEnergy");
 		
@@ -156,8 +159,8 @@ public class InventoryFrequency extends Frequency
 	{
 		super.read(dataStream);
 		
-		storedFluid = new FluidTank(1000);
-		storedGas = new GasTank(1000);
+		storedFluid = new FluidTank(FLUID_TANK_SIZE);
+		storedGas = new GasTank(GAS_TANK_SIZE);
 		
 		storedEnergy = dataStream.readDouble();
 		

--- a/src/main/java/mekanism/common/frequency/Frequency.java
+++ b/src/main/java/mekanism/common/frequency/Frequency.java
@@ -13,6 +13,8 @@ import mekanism.common.util.MekanismUtils;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.common.UsernameCache;
 
+import javax.annotation.Nullable;
+
 public class Frequency
 {
 	public static final String TELEPORTER = "Teleporter";
@@ -146,5 +148,37 @@ public class Frequency
 	{
 		return obj instanceof Frequency && ((Frequency)obj).name.equals(name) 
 				&& ((Frequency)obj).ownerUUID.equals(ownerUUID) && ((Frequency)obj).publicFreq == publicFreq;
+	}
+
+	public Identity getIdentity(){
+		return new Identity(this.name, this.publicFreq);
+	}
+
+	public static class Identity {
+		public String name;
+		public boolean publicFreq;
+
+		private Identity(String name, boolean publicFreq)
+		{
+			this.name = name;
+			this.publicFreq = publicFreq;
+		}
+
+		@Nullable
+		public static Identity load(NBTTagCompound data)
+		{
+			if (!data.getString("name").isEmpty()){
+				return new Identity(data.getString("name"), data.getBoolean("publicFreq"));
+			}
+			return null;
+		}
+
+		public NBTTagCompound serialise()
+		{
+			NBTTagCompound tag = new NBTTagCompound();
+			tag.setString("name", this.name);
+			tag.setBoolean("publicFreq", this.publicFreq);
+			return tag;
+		}
 	}
 }

--- a/src/main/java/mekanism/common/inventory/InventoryList.java
+++ b/src/main/java/mekanism/common/inventory/InventoryList.java
@@ -1,0 +1,198 @@
+package mekanism.common.inventory;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.inventory.ItemStackHelper;
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.NonNullList;
+import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.TextComponentString;
+import net.minecraft.util.text.TextComponentTranslation;
+
+/*Copied & modified from net.minecraft.inventory.InventoryBasic */
+public class InventoryList implements IInventory
+{
+    private String inventoryTitle;
+    private final int slotsCount;
+    private final NonNullList<ItemStack> inventoryContents;
+    private final TileEntity te;
+
+    public InventoryList(NonNullList<ItemStack> list, TileEntity parent)
+    {
+        this.inventoryTitle = "Proxy";
+        this.slotsCount = list.size();
+        this.inventoryContents = list;
+        this.te = parent;
+    }
+
+    /**
+     * Returns the stack in the given slot.
+     */
+    public ItemStack getStackInSlot(int index)
+    {
+        return index >= 0 && index < this.inventoryContents.size() ? (ItemStack)this.inventoryContents.get(index) : ItemStack.EMPTY;
+    }
+
+    /**
+     * Removes up to a specified number of items from an inventory slot and returns them in a new stack.
+     */
+    public ItemStack decrStackSize(int index, int count)
+    {
+        ItemStack itemstack = ItemStackHelper.getAndSplit(this.inventoryContents, index, count);
+
+        if (!itemstack.isEmpty())
+        {
+            this.markDirty();
+        }
+
+        return itemstack;
+    }
+
+    /**
+     * Removes a stack from the given slot and returns it.
+     */
+    public ItemStack removeStackFromSlot(int index)
+    {
+        ItemStack itemstack = (ItemStack)this.inventoryContents.get(index);
+
+        if (itemstack.isEmpty())
+        {
+            return ItemStack.EMPTY;
+        }
+        else
+        {
+            this.inventoryContents.set(index, ItemStack.EMPTY);
+            return itemstack;
+        }
+    }
+
+    /**
+     * Sets the given item stack to the specified slot in the inventory (can be crafting or armor sections).
+     */
+    public void setInventorySlotContents(int index, ItemStack stack)
+    {
+        this.inventoryContents.set(index, stack);
+
+        if (!stack.isEmpty() && stack.getCount() > this.getInventoryStackLimit())
+        {
+            stack.setCount(this.getInventoryStackLimit());
+        }
+
+        this.markDirty();
+    }
+
+    /**
+     * Returns the number of slots in the inventory.
+     */
+    public int getSizeInventory()
+    {
+        return this.slotsCount;
+    }
+
+    public boolean isEmpty()
+    {
+        for (ItemStack itemstack : this.inventoryContents)
+        {
+            if (!itemstack.isEmpty())
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Get the name of this object. For players this returns their username
+     */
+    public String getName()
+    {
+        return this.inventoryTitle;
+    }
+
+    /**
+     * Returns true if this thing is named
+     */
+    public boolean hasCustomName()
+    {
+        return false;
+    }
+
+    /**
+     * Sets the name of this inventory. This is displayed to the client on opening.
+     */
+    public void setCustomName(String inventoryTitleIn)
+    {
+
+    }
+
+    /**
+     * Get the formatted ChatComponent that will be used for the sender's username in chat
+     */
+    public ITextComponent getDisplayName()
+    {
+        return (ITextComponent)(this.hasCustomName() ? new TextComponentString(this.getName()) : new TextComponentTranslation(this.getName(), new Object[0]));
+    }
+
+    /**
+     * Returns the maximum stack size for a inventory slot. Seems to always be 64, possibly will be extended.
+     */
+    public int getInventoryStackLimit()
+    {
+        return 64;
+    }
+
+    /**
+     * For tile entities, ensures the chunk containing the tile entity is saved to disk later - the game won't think it
+     * hasn't changed and skip it.
+     */
+    public void markDirty()
+    {
+        this.te.markDirty();
+    }
+
+    /**
+     * Don't rename this method to canInteractWith due to conflicts with Container
+     */
+    public boolean isUsableByPlayer(EntityPlayer player)
+    {
+        return true;
+    }
+
+    public void openInventory(EntityPlayer player)
+    {
+    }
+
+    public void closeInventory(EntityPlayer player)
+    {
+    }
+
+    /**
+     * Returns true if automation is allowed to insert the given stack (ignoring stack size) into the given slot. For
+     * guis use Slot.isItemValid
+     */
+    public boolean isItemValidForSlot(int index, ItemStack stack)
+    {
+        return true;
+    }
+
+    public int getField(int id)
+    {
+        return 0;
+    }
+
+    public void setField(int id, int value)
+    {
+    }
+
+    public int getFieldCount()
+    {
+        return 0;
+    }
+
+    public void clear()
+    {
+        this.inventoryContents.clear();
+    }
+}

--- a/src/main/java/mekanism/common/inventory/container/ContainerUpgradeManagement.java
+++ b/src/main/java/mekanism/common/inventory/container/ContainerUpgradeManagement.java
@@ -21,6 +21,8 @@ public class ContainerUpgradeManagement extends Container
 	public ContainerUpgradeManagement(InventoryPlayer inventory, IUpgradeTile tile)
 	{
 		tileEntity = tile;
+
+		//Bit of a hack I guess, but we need to give it access to the inventory list, not the Frequency
 		IInventory upgradeInv;
 		if (tileEntity instanceof TileEntityQuantumEntangloporter)
 		{

--- a/src/main/java/mekanism/common/inventory/container/ContainerUpgradeManagement.java
+++ b/src/main/java/mekanism/common/inventory/container/ContainerUpgradeManagement.java
@@ -2,13 +2,17 @@ package mekanism.common.inventory.container;
 
 import mekanism.common.base.IUpgradeItem;
 import mekanism.common.base.IUpgradeTile;
+import mekanism.common.inventory.InventoryList;
 import mekanism.common.inventory.slot.SlotMachineUpgrade;
+import mekanism.common.tile.TileEntityQuantumEntangloporter;
 import mekanism.common.tile.prefab.TileEntityContainerBlock;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.Container;
+import net.minecraft.inventory.IInventory;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
 
 public class ContainerUpgradeManagement extends Container
 {
@@ -17,7 +21,17 @@ public class ContainerUpgradeManagement extends Container
 	public ContainerUpgradeManagement(InventoryPlayer inventory, IUpgradeTile tile)
 	{
 		tileEntity = tile;
-		addSlotToContainer(new SlotMachineUpgrade((TileEntityContainerBlock)tile, tileEntity.getComponent().getUpgradeSlot(), 154, 7));
+		IInventory upgradeInv;
+		if (tileEntity instanceof TileEntityQuantumEntangloporter)
+		{
+			upgradeInv = new InventoryList(((TileEntityQuantumEntangloporter) tileEntity).inventory, (TileEntity) tileEntity);
+		}
+		else
+		{
+			upgradeInv = (TileEntityContainerBlock)tile;
+		}
+
+		addSlotToContainer(new SlotMachineUpgrade(upgradeInv, tileEntity.getComponent().getUpgradeSlot(), 154, 7));
 		
 		int slotY;
 

--- a/src/main/java/mekanism/common/item/ItemBlockMachine.java
+++ b/src/main/java/mekanism/common/item/ItemBlockMachine.java
@@ -35,6 +35,7 @@ import mekanism.common.base.IUpgradeTile;
 import mekanism.common.block.states.BlockStateMachine.MachineType;
 import mekanism.common.capabilities.ItemCapabilityWrapper;
 import mekanism.common.config.MekanismConfig.general;
+import mekanism.common.frequency.Frequency;
 import mekanism.common.integration.forgeenergy.ForgeEnergyItemWrapper;
 import mekanism.common.integration.ic2.IC2Integration;
 import mekanism.common.integration.ic2.IC2ItemManager;
@@ -46,6 +47,7 @@ import mekanism.common.security.ISecurityTile;
 import mekanism.common.security.ISecurityTile.SecurityMode;
 import mekanism.common.tile.TileEntityFactory;
 import mekanism.common.tile.TileEntityFluidTank;
+import mekanism.common.tile.TileEntityQuantumEntangloporter;
 import mekanism.common.tile.prefab.TileEntityBasicBlock;
 import mekanism.common.tile.prefab.TileEntityElectricBlock;
 import mekanism.common.util.ItemDataUtils;
@@ -241,6 +243,15 @@ public class ItemBlockMachine extends ItemBlock implements IEnergizedItem, ISpec
 				list.add(EnumColor.INDIGO + LangUtils.localize("tooltip.portableTank.bucketMode") + ": " + EnumColor.GREY + LangUtils.transYesNo(getBucketMode(itemstack)));
 			}
 
+			if (type == MachineType.QUANTUM_ENTANGLOPORTER)
+			{
+				Frequency.Identity freq = Frequency.Identity.load(ItemDataUtils.getCompound(itemstack, "entangleporter_frequency"));
+				if (freq != null)
+				{
+					list.add(EnumColor.INDIGO + LangUtils.localize("gui.frequency") + ": "+EnumColor.GREY + freq.name + " (" + LangUtils.localize(freq.publicFreq ? "security.public" : "security.private") + ")");
+				}
+			}
+
 			if(type.isElectric)
 			{
 				list.add(EnumColor.BRIGHT_GREEN + LangUtils.localize("tooltip.storedEnergy") + ": " + EnumColor.GREY + MekanismUtils.getEnergyDisplay(getEnergy(itemstack), getMaxEnergy(itemstack)));
@@ -412,6 +423,15 @@ public class ItemBlockMachine extends ItemBlock implements IEnergizedItem, ISpec
 			if(tileEntity instanceof TileEntityElectricBlock)
 			{
 				((TileEntityElectricBlock)tileEntity).electricityStored = getEnergy(stack);
+			}
+
+			if (tileEntity instanceof TileEntityQuantumEntangloporter && ItemDataUtils.hasData(stack, "entangleporter_frequency"))
+			{
+				Frequency.Identity freq = Frequency.Identity.load(ItemDataUtils.getCompound(stack, "entangleporter_frequency"));
+				if (freq != null)
+				{
+					((TileEntityQuantumEntangloporter) tileEntity).setFrequency(freq.name, freq.publicFreq);
+				}
 			}
 
 			return true;

--- a/src/main/java/mekanism/common/tile/TileEntityQuantumEntangloporter.java
+++ b/src/main/java/mekanism/common/tile/TileEntityQuantumEntangloporter.java
@@ -410,7 +410,7 @@ public class TileEntityQuantumEntangloporter extends TileEntityElectricBlock imp
 	@Override
 	public double getMaxEnergy()
 	{
-		return !hasFrequency() ? 0 : frequency.MAX_ENERGY;
+		return !hasFrequency() ? 0 : InventoryFrequency.MAX_ENERGY;
 	}
 
 	@Override

--- a/src/main/java/mekanism/common/tile/TileEntityQuantumEntangloporter.java
+++ b/src/main/java/mekanism/common/tile/TileEntityQuantumEntangloporter.java
@@ -3,9 +3,11 @@ package mekanism.common.tile;
 import io.netty.buffer.ByteBuf;
 
 import java.util.ArrayList;
-import java.util.EnumSet;
+import java.util.Set;
+import java.util.HashSet;
 import java.util.List;
 
+import mekanism.api.Chunk3D;
 import mekanism.api.Coord4D;
 import mekanism.api.IHeatTransfer;
 import mekanism.api.gas.Gas;
@@ -16,20 +18,17 @@ import mekanism.api.transmitters.TransmissionType;
 import mekanism.common.Mekanism;
 import mekanism.common.PacketHandler;
 import mekanism.common.SideData.IOState;
-import mekanism.common.base.FluidHandlerWrapper;
-import mekanism.common.base.IFluidHandlerWrapper;
-import mekanism.common.base.ISideConfiguration;
-import mekanism.common.base.ITankManager;
+import mekanism.common.Upgrade;
+import mekanism.common.base.*;
 import mekanism.common.capabilities.Capabilities;
+import mekanism.common.chunkloading.IChunkLoader;
 import mekanism.common.content.entangloporter.InventoryFrequency;
 import mekanism.common.frequency.Frequency;
 import mekanism.common.frequency.FrequencyManager;
 import mekanism.common.frequency.IFrequencyHandler;
 import mekanism.common.integration.computer.IComputerIntegration;
 import mekanism.common.security.ISecurityTile;
-import mekanism.common.tile.component.TileComponentConfig;
-import mekanism.common.tile.component.TileComponentEjector;
-import mekanism.common.tile.component.TileComponentSecurity;
+import mekanism.common.tile.component.*;
 import mekanism.common.tile.prefab.TileEntityElectricBlock;
 import mekanism.common.util.CableUtils;
 import mekanism.common.util.CapabilityUtils;
@@ -39,17 +38,20 @@ import mekanism.common.util.MekanismUtils;
 import mekanism.common.util.PipeUtils;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagList;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.NonNullList;
+import net.minecraft.util.math.ChunkPos;
 import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.util.Constants;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTankInfo;
 import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
 import net.minecraftforge.fml.common.FMLCommonHandler;
 
-public class TileEntityQuantumEntangloporter extends TileEntityElectricBlock implements ISideConfiguration, ITankManager, IFluidHandlerWrapper, IFrequencyHandler, IGasHandler, IHeatTransfer, ITubeConnection, IComputerIntegration, ISecurityTile
+public class TileEntityQuantumEntangloporter extends TileEntityElectricBlock implements ISideConfiguration, ITankManager, IFluidHandlerWrapper, IFrequencyHandler, IGasHandler, IHeatTransfer, ITubeConnection, IComputerIntegration, ISecurityTile, IChunkLoader, IUpgradeTile
 {
 	public InventoryFrequency frequency;
 	
@@ -64,6 +66,10 @@ public class TileEntityQuantumEntangloporter extends TileEntityElectricBlock imp
 	public TileComponentEjector ejectorComponent;
 	public TileComponentConfig configComponent;
 	public TileComponentSecurity securityComponent;
+	public TileComponentChunkLoader chunkLoaderComponent;
+	public TileComponentUpgrade upgradeComponent;
+
+	private static final int INV_SIZE = 1;//this.inventory size, used for upgrades. Manually handled
 
 	public TileEntityQuantumEntangloporter()
 	{
@@ -82,7 +88,7 @@ public class TileEntityQuantumEntangloporter extends TileEntityElectricBlock imp
 			}
 		}
 
-		inventory = NonNullList.withSize(0, ItemStack.EMPTY);
+		inventory = NonNullList.withSize(INV_SIZE, ItemStack.EMPTY);
 		
 		configComponent.getOutputs(TransmissionType.ITEM).get(2).availableSlots = new int[] {0};
 		configComponent.getOutputs(TransmissionType.FLUID).get(2).availableSlots = new int[] {0};
@@ -94,6 +100,11 @@ public class TileEntityQuantumEntangloporter extends TileEntityElectricBlock imp
 		ejectorComponent.setOutputData(TransmissionType.GAS, configComponent.getOutputs(TransmissionType.GAS).get(2));
 		
 		securityComponent = new TileComponentSecurity(this);
+		chunkLoaderComponent = new TileComponentChunkLoader(this);
+
+		upgradeComponent = new TileComponentUpgrade(this, 0);
+		upgradeComponent.clearSupportedTypes();
+		upgradeComponent.setSupported(Upgrade.ANCHOR);
 	}
 
 	@Override
@@ -241,6 +252,21 @@ public class TileEntityQuantumEntangloporter extends TileEntityElectricBlock imp
 			frequency = new InventoryFrequency(nbtTags.getCompoundTag("frequency"));
 			frequency.valid = false;
 		}
+
+		NBTTagList tagList = nbtTags.getTagList("upgradesInv", Constants.NBT.TAG_COMPOUND);
+		inventory = NonNullList.withSize(INV_SIZE, ItemStack.EMPTY);
+
+		for(int tagCount = 0; tagCount < tagList.tagCount(); tagCount++)
+		{
+			NBTTagCompound tagCompound = tagList.getCompoundTagAt(tagCount);
+			byte slotID = tagCompound.getByte("Slot");
+
+			if(slotID >= 0 && slotID < inventory.size())
+			{
+				inventory.set(slotID, InventoryUtils.loadFromNBT(tagCompound));
+			}
+		}
+
 	}
 
 	@Override
@@ -254,6 +280,21 @@ public class TileEntityQuantumEntangloporter extends TileEntityElectricBlock imp
 			frequency.write(frequencyTag);
 			nbtTags.setTag("frequency", frequencyTag);
 		}
+
+		//Upgrades inventory
+		NBTTagList tagList = new NBTTagList();
+		for(int slotCount = 0; slotCount < inventory.size(); slotCount++)
+		{
+			ItemStack stackInSlot = inventory.get(slotCount);
+			if(!stackInSlot.isEmpty())
+			{
+				NBTTagCompound tagCompound = new NBTTagCompound();
+				tagCompound.setByte("Slot", (byte)slotCount);
+				stackInSlot.writeToNBT(tagCompound);
+				tagList.appendTag(tagCompound);
+			}
+		}
+		nbtTags.setTag("upgradesInv", tagList);
 		
 		return nbtTags;
 	}
@@ -705,5 +746,27 @@ public class TileEntityQuantumEntangloporter extends TileEntityElectricBlock imp
 			default:
 				throw new NoSuchMethodException();
 		}
+	}
+
+	@Override
+	public TileComponentChunkLoader getChunkLoader()
+	{
+		return chunkLoaderComponent;
+	}
+
+	@Override
+	public Set<ChunkPos> getChunkSet()
+	{
+		Set<ChunkPos> ret = new HashSet<ChunkPos>();
+
+		ret.add(new Chunk3D(Coord4D.get(this)).getPos());
+
+		return ret;
+	}
+
+	@Override
+	public TileComponentUpgrade getComponent()
+	{
+		return this.upgradeComponent;
 	}
 }

--- a/src/main/java/mekanism/common/tile/component/TileComponentUpgrade.java
+++ b/src/main/java/mekanism/common/tile/component/TileComponentUpgrade.java
@@ -55,6 +55,7 @@ public class TileComponentUpgrade implements ITileComponent
 		upgradeTicks = upgrade.upgradeTicks;
 	}
 
+	// This SHOULD continue to directly use te.inventory, as it is needed for Entangleporter upgrades, since it messes with IInventory.
 	@Override
 	public void tick()
 	{


### PR DESCRIPTION
Implements #4503, #3846, and half of what #3953 wants.

As for #3953 I've not changed the amount by which tiles emit to pipes, but have increased the buffer capacity to the same as the ultimate tiers of cable/pipe/tube can handle, so in theory transmitters can *pull* at their full rate, on one side of the porter at least.

Frequency storage in the itemstack stores only the name & public/private flag, so private frequencies should attach themselves to the placing player (e.g. should it be different to the frequency's).

Anchor upgrade is copied from the teleporter - loads just the tile's chunk.