### PR TITLE
Fix personal chests

### DIFF
--- a/src/main/java/mekanism/common/inventory/container/ContainerPersonalChest.java
+++ b/src/main/java/mekanism/common/inventory/container/ContainerPersonalChest.java
@@ -48,13 +48,13 @@ public class ContainerPersonalChest extends Container
 		{
 			for(int slotY = 0; slotY < 9; ++slotY)
 			{
-				addSlotToContainer(new SlotPersonalChest(inventory, slotY + slotX * 9 + 9, 8 + slotY * 18, 148 + slotX * 18));
+				addSlotToContainer(new Slot(inventory, slotY + slotX * 9 + 9, 8 + slotY * 18, 148 + slotX * 18));
 			}
 		}
 
 		for(slotX = 0; slotX < 9; ++slotX)
 		{
-			addSlotToContainer(new SlotPersonalChest(inventory, slotX, 8 + slotX * 18, 206));
+			addSlotToContainer(new Slot(inventory, slotX, 8 + slotX * 18, 206));
 		}
 	}
 
@@ -138,18 +138,21 @@ public class ContainerPersonalChest extends Container
 	}
 
 	@Override
-	public ItemStack slotClick(int slotNumber, int destSlot, ClickType clickType, EntityPlayer player)
+	public ItemStack slotClick(int slotId, int dragType, ClickType clickType, EntityPlayer player)
 	{
-		if(destSlot >= 0 && destSlot < 9)
+		int hotbarSlotId = slotId-81;
+
+		//Disallow moving Personal Chest if held and accessed directly from inventory (not from a placed block)
+		if(!isBlock && hotbarSlotId >= 0 && hotbarSlotId < 9 && player.inventory.currentItem == hotbarSlotId)
 		{
-			ItemStack itemStack = player.inventory.getStackInSlot(destSlot);
-			
+			ItemStack itemStack = player.inventory.getStackInSlot(hotbarSlotId);
+
 			if(!itemStack.isEmpty() && MachineType.get(itemStack) == MachineType.PERSONAL_CHEST)
 			{
 				return ItemStack.EMPTY;
 			}
 		}
 
-		return super.slotClick(slotNumber, destSlot, clickType, player);
+		return super.slotClick(slotId, dragType, clickType, player);
 	}
 }

--- a/src/main/java/mekanism/common/inventory/slot/SlotPersonalChest.java
+++ b/src/main/java/mekanism/common/inventory/slot/SlotPersonalChest.java
@@ -4,6 +4,7 @@ import mekanism.common.block.states.BlockStateMachine.MachineType;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.inventory.Slot;
+import net.minecraft.item.ItemStack;
 
 public class SlotPersonalChest extends Slot
 {
@@ -21,5 +22,16 @@ public class SlotPersonalChest extends Slot
 		}
 		
 		return MachineType.get(inventory.getStackInSlot(getSlotIndex())) != MachineType.PERSONAL_CHEST;
+	}
+
+	@Override
+	public boolean isItemValid(ItemStack stack)
+	{
+		if(MachineType.get(stack) == MachineType.PERSONAL_CHEST)
+		{
+			return false;
+		}
+
+		return super.isItemValid(stack);
 	}
 }


### PR DESCRIPTION
Current behaviour is as follows:
The top 6 rows (the real slots for personal chest) disallow placing personal chests in them through SlotPersonalChest.
The other rows (the real player inventory) do allow placing/moving personal chests.
One exception to this is when the personal chest is opened from the hotbar, it disallowes moving the opened chest in the hotbar.

Adresses #4634