### PR TITLE
Allow creating diamond ore with the combiner

### DIFF
--- a/src/main/java/mekanism/common/integration/OreDictManager.java
+++ b/src/main/java/mekanism/common/integration/OreDictManager.java
@@ -266,6 +266,7 @@ public final class OreDictManager
 		
 		for(ItemStack ore : OreDictionary.getOres("dustDiamond"))
 		{
+			RecipeHandler.addCombinerRecipe(StackUtils.size(ore, 3), new ItemStack(Blocks.DIAMOND_ORE));
 			InfuseRegistry.registerInfuseObject(ore, new InfuseObject(InfuseRegistry.get("DIAMOND"), 10));
 			RecipeHandler.addEnrichmentChamberRecipe(StackUtils.size(ore, 1), new ItemStack(Items.DIAMOND));
 		}


### PR DESCRIPTION
Add a combiner recipe for 3 x Diamond Dust -> 1 x Diamond Ore. This is in line
with the rest of the dust recipes, and it doesn't allow getting infinite
diamonds, since even with fortune 3, you only get an average of 2.5 diamonds
(and thus 2.5 diamond dusts) per ore.