### PR TITLE
Fix #4648: Let the combiner combine with things other than cobblestone

### DIFF
--- a/src/main/java/mekanism/client/ClientProxy.java
+++ b/src/main/java/mekanism/client/ClientProxy.java
@@ -190,6 +190,7 @@ import mekanism.common.tile.TileEntitySolarNeutronActivator;
 import mekanism.common.tile.TileEntityTeleporter;
 import mekanism.common.tile.TileEntityThermalEvaporationController;
 import mekanism.common.tile.prefab.TileEntityAdvancedElectricMachine;
+import mekanism.common.tile.prefab.TileEntityDoubleElectricMachine;
 import mekanism.common.tile.prefab.TileEntityElectricMachine;
 import mekanism.common.tile.transmitter.TileEntityDiversionTransporter;
 import mekanism.common.tile.transmitter.TileEntityLogisticalTransporter;
@@ -788,7 +789,7 @@ public class ClientProxy extends CommonProxy
 			case 4:
 				return new GuiOsmiumCompressor(player.inventory, (TileEntityAdvancedElectricMachine)tileEntity);
 			case 5:
-				return new GuiCombiner(player.inventory, (TileEntityAdvancedElectricMachine)tileEntity);
+				return new GuiCombiner(player.inventory, (TileEntityDoubleElectricMachine)tileEntity);
 			case 6:
 				return new GuiCrusher(player.inventory, (TileEntityElectricMachine)tileEntity);
 			case 7:

--- a/src/main/java/mekanism/client/gui/GuiCombiner.java
+++ b/src/main/java/mekanism/client/gui/GuiCombiner.java
@@ -1,15 +1,15 @@
 package mekanism.client.gui;
 
 import mekanism.client.gui.element.GuiProgress.ProgressBar;
-import mekanism.common.tile.prefab.TileEntityAdvancedElectricMachine;
+import mekanism.common.tile.prefab.TileEntityDoubleElectricMachine;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
 @SideOnly(Side.CLIENT)
-public class GuiCombiner extends GuiAdvancedElectricMachine
+public class GuiCombiner extends GuiDoubleElectricMachine
 {
-	public GuiCombiner(InventoryPlayer inventory, TileEntityAdvancedElectricMachine tentity)
+	public GuiCombiner(InventoryPlayer inventory, TileEntityDoubleElectricMachine tentity)
 	{
 		super(inventory, tentity);
 	}

--- a/src/main/java/mekanism/client/gui/GuiDoubleElectricMachine.java
+++ b/src/main/java/mekanism/client/gui/GuiDoubleElectricMachine.java
@@ -1,0 +1,108 @@
+package mekanism.client.gui;
+
+import mekanism.api.gas.GasStack;
+import mekanism.client.gui.element.GuiEnergyInfo;
+import mekanism.client.gui.element.GuiPowerBar;
+import mekanism.client.gui.element.GuiProgress;
+import mekanism.client.gui.element.GuiProgress.IProgressInfoHandler;
+import mekanism.client.gui.element.GuiProgress.ProgressBar;
+import mekanism.client.gui.element.GuiRedstoneControl;
+import mekanism.client.gui.element.GuiSecurityTab;
+import mekanism.client.gui.element.GuiSideConfigurationTab;
+import mekanism.client.gui.element.GuiSlot;
+import mekanism.client.gui.element.GuiSlot.SlotOverlay;
+import mekanism.client.gui.element.GuiSlot.SlotType;
+import mekanism.client.gui.element.GuiTransporterConfigTab;
+import mekanism.client.gui.element.GuiUpgradeTab;
+import mekanism.client.render.MekanismRenderer;
+import mekanism.common.inventory.container.ContainerDoubleElectricMachine;
+import mekanism.common.tile.prefab.TileEntityDoubleElectricMachine;
+import mekanism.common.util.LangUtils;
+import mekanism.common.util.ListUtils;
+import mekanism.common.util.MekanismUtils;
+import net.minecraft.entity.player.InventoryPlayer;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+
+import org.lwjgl.opengl.GL11;
+
+@SideOnly(Side.CLIENT)
+public class GuiDoubleElectricMachine extends GuiMekanism
+{
+	public TileEntityDoubleElectricMachine tileEntity;
+
+	public GuiDoubleElectricMachine(InventoryPlayer inventory, TileEntityDoubleElectricMachine tentity)
+	{
+		super(tentity, new ContainerDoubleElectricMachine(inventory, tentity));
+		tileEntity = tentity;
+
+		guiElements.add(new GuiRedstoneControl(this, tileEntity, tileEntity.guiLocation));
+		guiElements.add(new GuiUpgradeTab(this, tileEntity, tileEntity.guiLocation));
+		guiElements.add(new GuiSecurityTab(this, tileEntity, tileEntity.guiLocation));
+		guiElements.add(new GuiSideConfigurationTab(this, tileEntity, tileEntity.guiLocation));
+		guiElements.add(new GuiTransporterConfigTab(this, 34, tileEntity, tileEntity.guiLocation));
+		guiElements.add(new GuiPowerBar(this, tileEntity, tileEntity.guiLocation, 164, 15));
+		guiElements.add(new GuiEnergyInfo(() ->
+		{
+            String multiplier = MekanismUtils.getEnergyDisplay(tileEntity.energyPerTick);
+            return ListUtils.asList(LangUtils.localize("gui.using") + ": " + multiplier + "/t", LangUtils.localize("gui.needed") + ": " + MekanismUtils.getEnergyDisplay(tileEntity.getMaxEnergy()-tileEntity.getEnergy()));
+        }, this, tileEntity.guiLocation));
+
+		guiElements.add(new GuiSlot(SlotType.INPUT, this, tileEntity.guiLocation, 55, 16));
+		guiElements.add(new GuiSlot(SlotType.POWER, this, tileEntity.guiLocation, 30, 34).with(SlotOverlay.POWER));
+		guiElements.add(new GuiSlot(SlotType.EXTRA, this, tileEntity.guiLocation, 55, 52));
+		guiElements.add(new GuiSlot(SlotType.OUTPUT_LARGE, this, tileEntity.guiLocation, 111, 30));
+
+		guiElements.add(new GuiProgress(new IProgressInfoHandler()
+		{
+			@Override
+			public double getProgress()
+			{
+				return tileEntity.getScaledProgress();
+			}
+		}, getProgressType(), this, tileEntity.guiLocation, 77, 37));
+	}
+	
+	public ProgressBar getProgressType()
+	{
+		return ProgressBar.BLUE;
+	}
+
+	@Override
+	protected void drawGuiContainerForegroundLayer(int mouseX, int mouseY)
+	{
+		int xAxis = (mouseX - (width - xSize) / 2);
+		int yAxis = (mouseY - (height - ySize) / 2);
+
+		fontRenderer.drawString(tileEntity.getName(), (xSize/2)-(fontRenderer.getStringWidth(tileEntity.getName())/2), 6, 0x404040);
+		fontRenderer.drawString(LangUtils.localize("container.inventory"), 8, (ySize - 96) + 2, 0x404040);
+
+		super.drawGuiContainerForegroundLayer(mouseX, mouseY);
+	}
+
+	@Override
+	protected void drawGuiContainerBackgroundLayer(float partialTick, int mouseX, int mouseY)
+	{
+		mc.renderEngine.bindTexture(tileEntity.guiLocation);
+		GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+		int guiWidth = (width - xSize) / 2;
+		int guiHeight = (height - ySize) / 2;
+		drawTexturedModalRect(guiWidth, guiHeight, 0, 0, xSize, ySize);
+
+		super.drawGuiContainerBackgroundLayer(partialTick, mouseX, mouseY);
+	}
+
+	public void displayGauge(int xPos, int yPos, int sizeX, int sizeY, GasStack gas)
+	{
+		if(gas == null)
+		{
+			return;
+		}
+
+		int guiWidth = (width - xSize) / 2;
+		int guiHeight = (height - ySize) / 2;
+
+		mc.renderEngine.bindTexture(MekanismRenderer.getBlocksTexture());
+		drawTexturedModalRect(guiWidth + xPos, guiHeight + yPos, gas.getGas().getSprite(), sizeX, sizeY);
+	}
+}

--- a/src/main/java/mekanism/client/gui/GuiDoubleElectricMachine.java
+++ b/src/main/java/mekanism/client/gui/GuiDoubleElectricMachine.java
@@ -62,7 +62,7 @@ public class GuiDoubleElectricMachine extends GuiMekanism
 			}
 		}, getProgressType(), this, tileEntity.guiLocation, 77, 37));
 	}
-	
+
 	public ProgressBar getProgressType()
 	{
 		return ProgressBar.BLUE;

--- a/src/main/java/mekanism/client/gui/GuiFactory.java
+++ b/src/main/java/mekanism/client/gui/GuiFactory.java
@@ -16,6 +16,7 @@ import mekanism.client.render.MekanismRenderer;
 import mekanism.client.sound.SoundHandler;
 import mekanism.common.Mekanism;
 import mekanism.common.Tier.FactoryTier;
+import mekanism.common.base.IFactory.MachineFuelType;
 import mekanism.common.base.IFactory.RecipeType;
 import mekanism.common.inventory.container.ContainerFactory;
 import mekanism.common.item.ItemGaugeDropper;
@@ -76,7 +77,7 @@ public class GuiFactory extends GuiMekanism
 
 		if(xAxis >= 8 && xAxis <= 168 && yAxis >= 78 && yAxis <= 83)
 		{
-			if(tileEntity.recipeType.usesFuel())
+			if(tileEntity.recipeType.getFuelType() == MachineFuelType.ADVANCED)
 			{
 				drawHoveringText(tileEntity.gasTank.getGas() != null ? tileEntity.gasTank.getGas().getGas().getLocalizedName() + ": " + tileEntity.gasTank.getStored() : LangUtils.localize("gui.none"), xAxis, yAxis);
 			}
@@ -119,7 +120,7 @@ public class GuiFactory extends GuiMekanism
 			drawTexturedModalRect(guiWidth + xPos, guiHeight + 33, 176, 52, 8, displayInt);
 		}
 
-		if(tileEntity.recipeType.usesFuel())
+		if(tileEntity.recipeType.getFuelType() == MachineFuelType.ADVANCED)
 		{
 			if(tileEntity.getScaledGasLevel(160) > 0)
 			{

--- a/src/main/java/mekanism/client/jei/MekanismJEI.java
+++ b/src/main/java/mekanism/client/jei/MekanismJEI.java
@@ -30,6 +30,7 @@ import mekanism.client.gui.element.GuiProgress.ProgressBar;
 import mekanism.client.jei.gas.GasStackRenderer;
 import mekanism.client.jei.machine.AdvancedMachineRecipeCategory;
 import mekanism.client.jei.machine.ChanceMachineRecipeCategory;
+import mekanism.client.jei.machine.DoubleMachineRecipeCategory;
 import mekanism.client.jei.machine.MachineRecipeCategory;
 import mekanism.client.jei.machine.advanced.ChemicalInjectionChamberRecipeWrapper;
 import mekanism.client.jei.machine.advanced.CombinerRecipeWrapper;
@@ -81,6 +82,7 @@ import mekanism.common.recipe.machines.CombinerRecipe;
 import mekanism.common.recipe.machines.CrusherRecipe;
 import mekanism.common.recipe.machines.CrystallizerRecipe;
 import mekanism.common.recipe.machines.DissolutionRecipe;
+import mekanism.common.recipe.machines.DoubleMachineRecipe;
 import mekanism.common.recipe.machines.EnrichmentRecipe;
 import mekanism.common.recipe.machines.InjectionRecipe;
 import mekanism.common.recipe.machines.MachineRecipe;
@@ -179,7 +181,8 @@ public class MekanismJEI implements IModPlugin
 		SolarNeutronRecipeCategory solarNeutronCategory = new SolarNeutronRecipeCategory(registry.getJeiHelpers().getGuiHelper());
 		ThermalEvaporationRecipeCategory thermalEvaporationCategory = new ThermalEvaporationRecipeCategory(registry.getJeiHelpers().getGuiHelper());
 
-		AdvancedMachineRecipeCategory advancedMachineRecipeCategoryCombiner = new AdvancedMachineRecipeCategory(registry.getJeiHelpers().getGuiHelper(), Recipe.COMBINER.name().toLowerCase(), "tile.MachineBlock.Combiner.name", ProgressBar.STONE);
+		DoubleMachineRecipeCategory doubleMachineRecipeCategoryCombiner = new DoubleMachineRecipeCategory(registry.getJeiHelpers().getGuiHelper(), Recipe.COMBINER.name().toLowerCase(), "tile.MachineBlock.Combiner.name", ProgressBar.STONE);
+
 		AdvancedMachineRecipeCategory advancedMachineRecipeCategoryPurificationChamber = new AdvancedMachineRecipeCategory(registry.getJeiHelpers().getGuiHelper(), Recipe.PURIFICATION_CHAMBER.name().toLowerCase(), "tile.MachineBlock.PurificationChamber.name", ProgressBar.RED);
 		AdvancedMachineRecipeCategory advancedMachineRecipeCategoryOsmiumCompressor = new AdvancedMachineRecipeCategory(registry.getJeiHelpers().getGuiHelper(), Recipe.OSMIUM_COMPRESSOR.name().toLowerCase(), "tile.MachineBlock.OsmiumCompressor.name", ProgressBar.RED);
 		AdvancedMachineRecipeCategory advancedMachineRecipeCategoryChemicalInjectionChamber = new AdvancedMachineRecipeCategory(registry.getJeiHelpers().getGuiHelper(), Recipe.CHEMICAL_INJECTION_CHAMBER.name().toLowerCase(), "nei.chemicalInjectionChamber", ProgressBar.YELLOW);
@@ -191,7 +194,7 @@ public class MekanismJEI implements IModPlugin
 
 		registry.addRecipeCategories(chemicalCrystallizerCategory, chemicalDissolutionChamberCategory, chemicalInfuserCategory, chemicalOxidizerCategory,
 				chemicalWasherCategory, electrolyticSeparatorCategory, metallurgicInfuserCategory, prcCategory, rotaryCondensentratorCategory, solarNeutronCategory,
-				thermalEvaporationCategory, advancedMachineRecipeCategoryCombiner, advancedMachineRecipeCategoryPurificationChamber, advancedMachineRecipeCategoryOsmiumCompressor,
+				thermalEvaporationCategory, doubleMachineRecipeCategoryCombiner, advancedMachineRecipeCategoryPurificationChamber, advancedMachineRecipeCategoryOsmiumCompressor,
 				advancedMachineRecipeCategoryChemicalInjectionChamber, chanceMachineRecipeCategoryPrecisionSawmill, machineRecipeCategoryEnrichment,
 				machineRecipeCategoryCrusher
 		);
@@ -212,7 +215,7 @@ public class MekanismJEI implements IModPlugin
 		addRecipes(registry, Recipe.CRUSHER, BasicMachineRecipe.class, CrusherRecipeWrapper.class, "mekanism.crusher");
 
 		registry.handleRecipes(CombinerRecipe.class, CombinerRecipeWrapper::new, "mekanism.combiner");
-		addRecipes(registry, Recipe.COMBINER, AdvancedMachineRecipe.class, CombinerRecipeWrapper.class, "mekanism.combiner");
+		addRecipes(registry, Recipe.COMBINER, DoubleMachineRecipe.class, CombinerRecipeWrapper.class, "mekanism.combiner");
 
 		registry.handleRecipes(PurificationRecipe.class, PurificationChamberRecipeWrapper::new, "mekanism.purification_chamber");
 		addRecipes(registry, Recipe.PURIFICATION_CHAMBER, AdvancedMachineRecipe.class, PurificationChamberRecipeWrapper.class, "mekanism.purification_chamber");

--- a/src/main/java/mekanism/client/jei/machine/DoubleMachineRecipeCategory.java
+++ b/src/main/java/mekanism/client/jei/machine/DoubleMachineRecipeCategory.java
@@ -1,0 +1,94 @@
+package mekanism.client.jei.machine;
+
+import mekanism.client.gui.element.GuiPowerBar;
+import mekanism.client.gui.element.GuiPowerBar.IPowerInfoHandler;
+import mekanism.client.gui.element.GuiProgress;
+import mekanism.client.gui.element.GuiProgress.IProgressInfoHandler;
+import mekanism.client.gui.element.GuiProgress.ProgressBar;
+import mekanism.client.gui.element.GuiSlot;
+import mekanism.client.gui.element.GuiSlot.SlotOverlay;
+import mekanism.client.gui.element.GuiSlot.SlotType;
+import mekanism.client.jei.BaseRecipeCategory;
+import mekanism.common.recipe.inputs.DoubleMachineInput;
+import mekanism.common.recipe.machines.DoubleMachineRecipe;
+import mekanism.common.recipe.outputs.ItemStackOutput;
+import mekanism.common.util.MekanismUtils;
+import mekanism.common.util.MekanismUtils.ResourceType;
+import mezz.jei.api.IGuiHelper;
+import mezz.jei.api.gui.IDrawable;
+import mezz.jei.api.gui.IGuiItemStackGroup;
+import mezz.jei.api.gui.IRecipeLayout;
+import mezz.jei.api.ingredients.IIngredients;
+import mezz.jei.api.recipe.IRecipeWrapper;
+import net.minecraft.util.ResourceLocation;
+
+import javax.annotation.Nullable;
+
+public class DoubleMachineRecipeCategory extends BaseRecipeCategory
+{
+	private final IDrawable background;
+
+	@Nullable
+	private DoubleMachineRecipe tempRecipe;
+	
+	public DoubleMachineRecipeCategory(IGuiHelper helper, String name, String unlocalized, ProgressBar progress)
+	{
+		super(helper, "mekanism:gui/guibasicmachine.png", name, unlocalized, progress);
+		
+		background = guiHelper.createDrawable(new ResourceLocation(guiTexture), 28, 16, 144, 54);
+	}
+	
+	@Override
+	public void addGuiElements()
+	{
+		guiElements.add(new GuiSlot(SlotType.INPUT, this, MekanismUtils.getResource(ResourceType.GUI, stripTexture()), 55, 16));
+		guiElements.add(new GuiSlot(SlotType.POWER, this, MekanismUtils.getResource(ResourceType.GUI, stripTexture()), 30, 34).with(SlotOverlay.POWER));
+		guiElements.add(new GuiSlot(SlotType.EXTRA, this, MekanismUtils.getResource(ResourceType.GUI, stripTexture()), 55, 52));
+		guiElements.add(new GuiSlot(SlotType.OUTPUT_LARGE, this, MekanismUtils.getResource(ResourceType.GUI, stripTexture()), 111, 30));
+		
+		guiElements.add(new GuiPowerBar(this, new IPowerInfoHandler() {
+			@Override
+			public double getLevel()
+			{
+				return 1F;
+			}
+		}, MekanismUtils.getResource(ResourceType.GUI, stripTexture()), 164, 15));
+		guiElements.add(new GuiProgress(new IProgressInfoHandler()
+		{
+			@Override
+			public double getProgress()
+			{
+				return (double)timer.getValue() / 20F;
+			}
+		}, progressBar, this, MekanismUtils.getResource(ResourceType.GUI, stripTexture()), 77, 37));
+	}
+
+	@Override
+	public IDrawable getBackground() 
+	{
+		return background;
+	}
+
+	@Override
+	public void setRecipe(IRecipeLayout recipeLayout, IRecipeWrapper recipeWrapper, IIngredients ingredients) 
+	{
+		if(!(recipeWrapper instanceof DoubleMachineRecipeWrapper))
+		{
+			return;
+		}
+
+		tempRecipe = ((DoubleMachineRecipeWrapper)recipeWrapper).getRecipe();
+		
+		DoubleMachineInput input = (DoubleMachineInput)tempRecipe.recipeInput;
+		
+		IGuiItemStackGroup itemStacks = recipeLayout.getItemStacks();
+		
+		itemStacks.init(0, true, 27, 0);
+		itemStacks.init(1, false, 87, 18);
+		itemStacks.init(2, false, 27, 36);
+
+		itemStacks.set(0, input.itemStack);
+		itemStacks.set(1, ((ItemStackOutput)tempRecipe.recipeOutput).output);
+		itemStacks.set(2, input.extraStack);
+	}
+}

--- a/src/main/java/mekanism/client/jei/machine/DoubleMachineRecipeCategory.java
+++ b/src/main/java/mekanism/client/jei/machine/DoubleMachineRecipeCategory.java
@@ -30,14 +30,14 @@ public class DoubleMachineRecipeCategory extends BaseRecipeCategory
 
 	@Nullable
 	private DoubleMachineRecipe tempRecipe;
-	
+
 	public DoubleMachineRecipeCategory(IGuiHelper helper, String name, String unlocalized, ProgressBar progress)
 	{
 		super(helper, "mekanism:gui/guibasicmachine.png", name, unlocalized, progress);
-		
+
 		background = guiHelper.createDrawable(new ResourceLocation(guiTexture), 28, 16, 144, 54);
 	}
-	
+
 	@Override
 	public void addGuiElements()
 	{
@@ -45,7 +45,7 @@ public class DoubleMachineRecipeCategory extends BaseRecipeCategory
 		guiElements.add(new GuiSlot(SlotType.POWER, this, MekanismUtils.getResource(ResourceType.GUI, stripTexture()), 30, 34).with(SlotOverlay.POWER));
 		guiElements.add(new GuiSlot(SlotType.EXTRA, this, MekanismUtils.getResource(ResourceType.GUI, stripTexture()), 55, 52));
 		guiElements.add(new GuiSlot(SlotType.OUTPUT_LARGE, this, MekanismUtils.getResource(ResourceType.GUI, stripTexture()), 111, 30));
-		
+
 		guiElements.add(new GuiPowerBar(this, new IPowerInfoHandler() {
 			@Override
 			public double getLevel()
@@ -64,13 +64,13 @@ public class DoubleMachineRecipeCategory extends BaseRecipeCategory
 	}
 
 	@Override
-	public IDrawable getBackground() 
+	public IDrawable getBackground()
 	{
 		return background;
 	}
 
 	@Override
-	public void setRecipe(IRecipeLayout recipeLayout, IRecipeWrapper recipeWrapper, IIngredients ingredients) 
+	public void setRecipe(IRecipeLayout recipeLayout, IRecipeWrapper recipeWrapper, IIngredients ingredients)
 	{
 		if(!(recipeWrapper instanceof DoubleMachineRecipeWrapper))
 		{
@@ -78,11 +78,11 @@ public class DoubleMachineRecipeCategory extends BaseRecipeCategory
 		}
 
 		tempRecipe = ((DoubleMachineRecipeWrapper)recipeWrapper).getRecipe();
-		
+
 		DoubleMachineInput input = (DoubleMachineInput)tempRecipe.recipeInput;
-		
+
 		IGuiItemStackGroup itemStacks = recipeLayout.getItemStacks();
-		
+
 		itemStacks.init(0, true, 27, 0);
 		itemStacks.init(1, false, 87, 18);
 		itemStacks.init(2, false, 27, 36);

--- a/src/main/java/mekanism/client/jei/machine/DoubleMachineRecipeWrapper.java
+++ b/src/main/java/mekanism/client/jei/machine/DoubleMachineRecipeWrapper.java
@@ -12,14 +12,14 @@ import net.minecraft.item.ItemStack;
 public abstract class DoubleMachineRecipeWrapper implements IRecipeWrapper
 {
 	private final DoubleMachineRecipe recipe;
-	
+
 	public DoubleMachineRecipeWrapper(DoubleMachineRecipe r)
 	{
 		recipe = r;
 	}
 
 	@Override
-	public void getIngredients(IIngredients ingredients) 
+	public void getIngredients(IIngredients ingredients)
 	{
 		DoubleMachineInput input = (DoubleMachineInput)recipe.getInput();
 		ingredients.setInputs(ItemStack.class, Arrays.asList(input.itemStack, input.extraStack));

--- a/src/main/java/mekanism/client/jei/machine/DoubleMachineRecipeWrapper.java
+++ b/src/main/java/mekanism/client/jei/machine/DoubleMachineRecipeWrapper.java
@@ -1,0 +1,33 @@
+package mekanism.client.jei.machine;
+
+import java.util.Arrays;
+
+import mekanism.common.recipe.inputs.DoubleMachineInput;
+import mekanism.common.recipe.machines.DoubleMachineRecipe;
+import mekanism.common.recipe.outputs.ItemStackOutput;
+import mezz.jei.api.ingredients.IIngredients;
+import mezz.jei.api.recipe.IRecipeWrapper;
+import net.minecraft.item.ItemStack;
+
+public abstract class DoubleMachineRecipeWrapper implements IRecipeWrapper
+{
+	private final DoubleMachineRecipe recipe;
+	
+	public DoubleMachineRecipeWrapper(DoubleMachineRecipe r)
+	{
+		recipe = r;
+	}
+
+	@Override
+	public void getIngredients(IIngredients ingredients) 
+	{
+		DoubleMachineInput input = (DoubleMachineInput)recipe.getInput();
+		ingredients.setInputs(ItemStack.class, Arrays.asList(input.itemStack, input.extraStack));
+		ingredients.setOutput(ItemStack.class, ((ItemStackOutput)recipe.getOutput()).output);
+	}
+
+	public DoubleMachineRecipe getRecipe()
+	{
+		return recipe;
+	}
+}

--- a/src/main/java/mekanism/client/jei/machine/advanced/CombinerRecipeWrapper.java
+++ b/src/main/java/mekanism/client/jei/machine/advanced/CombinerRecipeWrapper.java
@@ -1,24 +1,12 @@
 package mekanism.client.jei.machine.advanced;
 
-import mekanism.api.gas.Gas;
-import mekanism.client.jei.machine.AdvancedMachineRecipeWrapper;
-import mekanism.common.recipe.machines.AdvancedMachineRecipe;
-import mekanism.common.util.ListUtils;
-import net.minecraft.init.Blocks;
-import net.minecraft.item.ItemStack;
+import mekanism.client.jei.machine.DoubleMachineRecipeWrapper;
+import mekanism.common.recipe.machines.DoubleMachineRecipe;
 
-import java.util.List;
-
-public class CombinerRecipeWrapper extends AdvancedMachineRecipeWrapper
+public class CombinerRecipeWrapper extends DoubleMachineRecipeWrapper
 {
-	public CombinerRecipeWrapper(AdvancedMachineRecipe r)
+	public CombinerRecipeWrapper(DoubleMachineRecipe r)
 	{
 		super(r);
-	}
-	
-	@Override
-	public List<ItemStack> getFuelStacks(Gas gasType)
-	{
-		return ListUtils.asList(new ItemStack(Blocks.COBBLESTONE));
 	}
 }

--- a/src/main/java/mekanism/common/CommonProxy.java
+++ b/src/main/java/mekanism/common/CommonProxy.java
@@ -23,6 +23,7 @@ import mekanism.common.inventory.container.ContainerChemicalOxidizer;
 import mekanism.common.inventory.container.ContainerChemicalWasher;
 import mekanism.common.inventory.container.ContainerDictionary;
 import mekanism.common.inventory.container.ContainerDigitalMiner;
+import mekanism.common.inventory.container.ContainerDoubleElectricMachine;
 import mekanism.common.inventory.container.ContainerDynamicTank;
 import mekanism.common.inventory.container.ContainerElectricMachine;
 import mekanism.common.inventory.container.ContainerElectricPump;
@@ -109,6 +110,7 @@ import mekanism.common.tile.TileEntityTeleporter;
 import mekanism.common.tile.TileEntityThermalEvaporationController;
 import mekanism.common.tile.prefab.TileEntityAdvancedElectricMachine;
 import mekanism.common.tile.prefab.TileEntityContainerBlock;
+import mekanism.common.tile.prefab.TileEntityDoubleElectricMachine;
 import mekanism.common.tile.prefab.TileEntityElectricMachine;
 import mekanism.common.tile.transmitter.TileEntityDiversionTransporter;
 import mekanism.common.tile.transmitter.TileEntityLogisticalTransporter;
@@ -432,7 +434,7 @@ public class CommonProxy implements IGuiProvider
 			case 4:
 				return new ContainerAdvancedElectricMachine(player.inventory, (TileEntityAdvancedElectricMachine)tileEntity);
 			case 5:
-				return new ContainerAdvancedElectricMachine(player.inventory, (TileEntityAdvancedElectricMachine)tileEntity);
+				return new ContainerDoubleElectricMachine(player.inventory, (TileEntityDoubleElectricMachine)tileEntity);
 			case 6:
 				return new ContainerElectricMachine(player.inventory, (TileEntityElectricMachine)tileEntity);
 			case 7:

--- a/src/main/java/mekanism/common/Mekanism.java
+++ b/src/main/java/mekanism/common/Mekanism.java
@@ -327,11 +327,12 @@ public class Mekanism
 		}
 		
 		//Combiner recipes
-		RecipeHandler.addCombinerRecipe(new ItemStack(Items.REDSTONE, 16), new ItemStack(Blocks.REDSTONE_ORE));
-		RecipeHandler.addCombinerRecipe(new ItemStack(Items.DYE, 16, 4), new ItemStack(Blocks.LAPIS_ORE));
-		RecipeHandler.addCombinerRecipe(new ItemStack(Items.FLINT), new ItemStack(Blocks.GRAVEL));
-		RecipeHandler.addCombinerRecipe(new ItemStack(Items.EMERALD, 3), new ItemStack(Blocks.EMERALD_ORE));
-		RecipeHandler.addCombinerRecipe(new ItemStack(Items.COAL, 3), new ItemStack(Blocks.COAL_ORE));
+		RecipeHandler.addCombinerRecipe(new ItemStack(Items.REDSTONE, 16), new ItemStack(Blocks.COBBLESTONE), new ItemStack(Blocks.REDSTONE_ORE));
+		RecipeHandler.addCombinerRecipe(new ItemStack(Items.DYE, 16, 4), new ItemStack(Blocks.COBBLESTONE), new ItemStack(Blocks.LAPIS_ORE));
+		RecipeHandler.addCombinerRecipe(new ItemStack(Items.FLINT), new ItemStack(Blocks.COBBLESTONE), new ItemStack(Blocks.GRAVEL));
+		RecipeHandler.addCombinerRecipe(new ItemStack(Items.EMERALD, 3), new ItemStack(Blocks.COBBLESTONE), new ItemStack(Blocks.EMERALD_ORE));
+		RecipeHandler.addCombinerRecipe(new ItemStack(Items.COAL, 3), new ItemStack(Blocks.COBBLESTONE), new ItemStack(Blocks.COAL_ORE));
+		RecipeHandler.addCombinerRecipe(new ItemStack(Items.QUARTZ, 3), new ItemStack(Blocks.NETHERRACK), new ItemStack(Blocks.QUARTZ_ORE));
 		
 		//Osmium Compressor Recipes
 		RecipeHandler.addOsmiumCompressorRecipe(new ItemStack(Items.GLOWSTONE_DUST), new ItemStack(MekanismItems.Ingot, 1, 3));

--- a/src/main/java/mekanism/common/MekanismFluids.java
+++ b/src/main/java/mekanism/common/MekanismFluids.java
@@ -23,7 +23,6 @@ public class MekanismFluids
 	
 	//Internal gases
 	public static final Gas LiquidOsmium = new Gas("liquidosmium", "mekanism:blocks/liquid/LiquidOsmium");
-	public static final Gas LiquidStone = new Gas("liquidstone", "mekanism:blocks/liquid/LiquidStone");
 	public static final Gas Ethene = new Gas("ethene", "mekanism:blocks/liquid/LiquidEthene");
 	public static final Gas Sodium = new Gas("sodium", "mekanism:blocks/liquid/LiquidSodium");
 	public static final Gas Brine = new Gas("brine", "mekanism:blocks/liquid/LiquidBrine");
@@ -51,7 +50,6 @@ public class MekanismFluids
 		GasRegistry.register(Lithium).registerFluid("liquidlithium");
 		
 		GasRegistry.register(LiquidOsmium).setVisible(false);
-		GasRegistry.register(LiquidStone).setVisible(false);
 		
 		FluidRegistry.registerFluid(HeavyWater);
 		FluidRegistry.registerFluid(Steam);

--- a/src/main/java/mekanism/common/integration/OreDictManager.java
+++ b/src/main/java/mekanism/common/integration/OreDictManager.java
@@ -122,7 +122,7 @@ public final class OreDictManager
 			try {
 				for(ItemStack ore : OreDictionary.getOres("dust" + resource.getName()))
 				{
-					RecipeHandler.addCombinerRecipe(StackUtils.size(ore, 8), StackUtils.size(OreDictionary.getOres("ore" + resource.getName()).get(0), 1));
+					RecipeHandler.addCombinerRecipe(StackUtils.size(ore, 8), new ItemStack(Blocks.COBBLESTONE), StackUtils.size(OreDictionary.getOres("ore" + resource.getName()).get(0), 1));
 				}
 			} catch(Exception e) {}
 		}
@@ -146,7 +146,7 @@ public final class OreDictManager
 			for(ItemStack ore : OreDictionary.getOres("dust" + s))
 			{
 				try {
-					RecipeHandler.addCombinerRecipe(StackUtils.size(ore, 8), StackUtils.size(OreDictionary.getOres("ore" + s).get(0), 1));
+					RecipeHandler.addCombinerRecipe(StackUtils.size(ore, 8), new ItemStack(Blocks.COBBLESTONE), StackUtils.size(OreDictionary.getOres("ore" + s).get(0), 1));
 				} catch(Exception e) {}
 			}
 		}
@@ -260,13 +260,13 @@ public final class OreDictManager
 		
 		for(ItemStack ore : OreDictionary.getOres("dustObsidian"))
 		{
-			RecipeHandler.addCombinerRecipe(StackUtils.size(ore, 4), new ItemStack(Blocks.OBSIDIAN));
+			RecipeHandler.addCombinerRecipe(StackUtils.size(ore, 4), new ItemStack(Blocks.COBBLESTONE), new ItemStack(Blocks.OBSIDIAN));
 			RecipeHandler.addMetallurgicInfuserRecipe(InfuseRegistry.get("DIAMOND"), 10, StackUtils.size(ore, 1), new ItemStack(MekanismItems.OtherDust, 1, 5));
 		}
 		
 		for(ItemStack ore : OreDictionary.getOres("dustDiamond"))
 		{
-			RecipeHandler.addCombinerRecipe(StackUtils.size(ore, 3), new ItemStack(Blocks.DIAMOND_ORE));
+			RecipeHandler.addCombinerRecipe(StackUtils.size(ore, 3), new ItemStack(Blocks.COBBLESTONE), new ItemStack(Blocks.DIAMOND_ORE));
 			InfuseRegistry.registerInfuseObject(ore, new InfuseObject(InfuseRegistry.get("DIAMOND"), 10));
 			RecipeHandler.addEnrichmentChamberRecipe(StackUtils.size(ore, 1), new ItemStack(Items.DIAMOND));
 		}

--- a/src/main/java/mekanism/common/integration/crafttweaker/handlers/Combiner.java
+++ b/src/main/java/mekanism/common/integration/crafttweaker/handlers/Combiner.java
@@ -47,8 +47,12 @@ public class Combiner
         CrafttweakerIntegration.LATE_ADDITIONS.add(new AddMekanismRecipe(NAME, RecipeHandler.Recipe.COMBINER.get(), recipe));
     }
 
+    /**
+     * @deprecated Replaced by {@link #addRecipe(IItemStack, IItemStack, IItemStack)}.
+     * May be removed with Minecraft 1.13.
+     */
     @ZenMethod
-    @Deprecated // TODO remove this method in MC 1.13
+    @Deprecated
     public static void addRecipe(IItemStack itemInput, IItemStack itemOutput)
     {
         if (itemInput == null || itemOutput == null)

--- a/src/main/java/mekanism/common/integration/crafttweaker/handlers/Combiner.java
+++ b/src/main/java/mekanism/common/integration/crafttweaker/handlers/Combiner.java
@@ -8,15 +8,11 @@ import crafttweaker.annotations.ZenRegister;
 import crafttweaker.api.item.IIngredient;
 import crafttweaker.api.item.IItemStack;
 import crafttweaker.api.item.IngredientAny;
-import mekanism.api.gas.GasStack;
 import mekanism.common.integration.crafttweaker.CrafttweakerIntegration;
-import mekanism.common.integration.crafttweaker.gas.CraftTweakerGasStack;
-import mekanism.common.integration.crafttweaker.gas.IGasStack;
-import mekanism.common.integration.crafttweaker.helpers.GasHelper;
 import mekanism.common.integration.crafttweaker.util.AddMekanismRecipe;
 import mekanism.common.integration.crafttweaker.util.RemoveMekanismRecipe;
 import mekanism.common.recipe.RecipeHandler;
-import mekanism.common.recipe.inputs.AdvancedMachineInput;
+import mekanism.common.recipe.inputs.DoubleMachineInput;
 import mekanism.common.recipe.inputs.MachineInput;
 import mekanism.common.recipe.machines.CombinerRecipe;
 import mekanism.common.recipe.machines.MachineRecipe;
@@ -36,15 +32,15 @@ public class Combiner
     public static final String NAME = "Mekanism Combiner";
 
     @ZenMethod
-    public static void addRecipe(IItemStack itemInput, IGasStack gasInput, IItemStack itemOutput)
+    public static void addRecipe(IItemStack itemInput, IItemStack extraInput, IItemStack itemOutput)
     {
-        if (itemInput == null || gasInput == null || itemOutput == null)
+        if (itemInput == null || extraInput == null || itemOutput == null)
         {
             LogHelper.logError(String.format("Required parameters missing for %s Recipe.", NAME));
             return;
         }
 
-        AdvancedMachineInput input = new AdvancedMachineInput(InputHelper.toStack(itemInput), GasHelper.toGas(gasInput).getGas());
+        DoubleMachineInput input = new DoubleMachineInput(InputHelper.toStack(itemInput), InputHelper.toStack(extraInput));
         ItemStackOutput output = new ItemStackOutput(InputHelper.toStack(itemOutput));
         CombinerRecipe recipe = new CombinerRecipe(input, output);
 
@@ -52,6 +48,7 @@ public class Combiner
     }
 
     @ZenMethod
+    @Deprecated
     public static void addRecipe(IItemStack itemInput, IItemStack itemOutput)
     {
         if (itemInput == null || itemOutput == null)
@@ -86,15 +83,15 @@ public class Combiner
     {
         private IIngredient itemOutput;
         private IIngredient itemInput;
-        private IIngredient gasInput;
+        private IIngredient itemExtra;
 
-        public Remove(String name, Map<MachineInput, MachineRecipe> map, IIngredient itemOutput, IIngredient itemInput, IIngredient gasInput)
+        public Remove(String name, Map<MachineInput, MachineRecipe> map, IIngredient itemOutput, IIngredient itemInput, IIngredient extraInput)
         {
             super(name, map);
 
             this.itemOutput = itemOutput;
             this.itemInput = itemInput;
-            this.gasInput = gasInput;
+            this.itemExtra = extraInput;
         }
 
         @Override
@@ -102,15 +99,15 @@ public class Combiner
         {
             Map<MachineInput, MachineRecipe> recipesToRemove = new HashMap<>();
 
-            for (Map.Entry<AdvancedMachineInput, CombinerRecipe> entry : ((Map<AdvancedMachineInput, CombinerRecipe>) RecipeHandler.Recipe.COMBINER.get()).entrySet())
+            for (Map.Entry<DoubleMachineInput, CombinerRecipe> entry : ((Map<DoubleMachineInput, CombinerRecipe>) RecipeHandler.Recipe.COMBINER.get()).entrySet())
             {
                 IItemStack inputItem = InputHelper.toIItemStack(entry.getKey().itemStack);
-                IGasStack inputGas = new CraftTweakerGasStack(new GasStack(entry.getKey().gasType, 1));
+                IItemStack extraItem = InputHelper.toIItemStack(entry.getKey().extraStack);
                 IItemStack outputItem = InputHelper.toIItemStack(entry.getValue().getOutput().output);
 
                 if (!StackHelper.matches(itemInput, inputItem))
                     continue;
-                if (!GasHelper.matches(gasInput, inputGas))
+                if (!StackHelper.matches(itemExtra, extraItem))
                     continue;
                 if (!StackHelper.matches(itemOutput, outputItem))
                     continue;
@@ -124,7 +121,7 @@ public class Combiner
             }
             else
             {
-                LogHelper.logWarning(String.format("No %s recipe found for %s, %s and %s. Command ignored!", NAME, itemInput.toString(), gasInput.toString(), itemOutput.toString()));
+                LogHelper.logWarning(String.format("No %s recipe found for %s, %s and %s. Command ignored!", NAME, itemInput.toString(), itemExtra.toString(), itemOutput.toString()));
             }
         }
     }

--- a/src/main/java/mekanism/common/integration/crafttweaker/handlers/Combiner.java
+++ b/src/main/java/mekanism/common/integration/crafttweaker/handlers/Combiner.java
@@ -48,7 +48,7 @@ public class Combiner
     }
 
     @ZenMethod
-    @Deprecated
+    @Deprecated // TODO remove this method in MC 1.13
     public static void addRecipe(IItemStack itemInput, IItemStack itemOutput)
     {
         if (itemInput == null || itemOutput == null)

--- a/src/main/java/mekanism/common/inventory/container/ContainerDoubleElectricMachine.java
+++ b/src/main/java/mekanism/common/inventory/container/ContainerDoubleElectricMachine.java
@@ -1,0 +1,195 @@
+package mekanism.common.inventory.container;
+
+import java.util.Map;
+
+import mekanism.common.inventory.slot.SlotEnergy.SlotDischarge;
+import mekanism.common.inventory.slot.SlotOutput;
+import mekanism.common.recipe.inputs.DoubleMachineInput;
+import mekanism.common.tile.prefab.TileEntityDoubleElectricMachine;
+import mekanism.common.util.ChargeUtils;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.InventoryPlayer;
+import net.minecraft.inventory.Container;
+import net.minecraft.inventory.Slot;
+import net.minecraft.item.ItemStack;
+
+public class ContainerDoubleElectricMachine extends Container
+{
+	private TileEntityDoubleElectricMachine tileEntity;
+
+	public ContainerDoubleElectricMachine(InventoryPlayer inventory, TileEntityDoubleElectricMachine tentity)
+	{
+		tileEntity = tentity;
+		addSlotToContainer(new Slot(tentity, 0, 56, 17));
+		addSlotToContainer(new Slot(tentity, 1, 56, 53));
+		addSlotToContainer(new SlotOutput(tentity, 2, 116, 35));
+		addSlotToContainer(new SlotDischarge(tentity, 3, 31, 35));
+
+		int slotY;
+
+		for(slotY = 0; slotY < 3; slotY++)
+		{
+			for(int slotX = 0; slotX < 9; slotX++)
+			{
+				addSlotToContainer(new Slot(inventory, slotX + slotY * 9 + 9, 8 + slotX * 18, 84 + slotY * 18));
+			}
+		}
+
+		for(slotY = 0; slotY < 9; slotY++)
+		{
+			addSlotToContainer(new Slot(inventory, slotY, 8 + slotY * 18, 142));
+		}
+
+		tileEntity.open(inventory.player);
+		tileEntity.openInventory(inventory.player);
+	}
+
+	@Override
+	public void onContainerClosed(EntityPlayer entityplayer)
+	{
+		super.onContainerClosed(entityplayer);
+
+		tileEntity.close(entityplayer);
+		tileEntity.closeInventory(entityplayer);
+	}
+
+	@Override
+	public boolean canInteractWith(EntityPlayer entityplayer)
+	{
+		return tileEntity.isUsableByPlayer(entityplayer);
+	}
+
+	@Override
+	public ItemStack transferStackInSlot(EntityPlayer player, int slotID)
+	{
+		ItemStack stack = ItemStack.EMPTY;
+		Slot currentSlot = (Slot)inventorySlots.get(slotID);
+
+		if(currentSlot != null && currentSlot.getHasStack())
+		{
+			ItemStack slotStack = currentSlot.getStack();
+			stack = slotStack.copy();
+
+			if(slotID == 2)
+			{
+				if(!mergeItemStack(slotStack, 4, inventorySlots.size(), true))
+				{
+					return ItemStack.EMPTY;
+				}
+			}
+			else if(ChargeUtils.canBeDischarged(slotStack))
+			{
+				if(slotID != 3)
+				{
+					if(!mergeItemStack(slotStack, 3, 4, false))
+					{
+						return ItemStack.EMPTY;
+					}
+				}
+				else {
+					if(!mergeItemStack(slotStack, 4, inventorySlots.size(), true))
+					{
+						return ItemStack.EMPTY;
+					}
+				}
+			}
+			else if(isExtraItem(slotStack))
+			{
+				if(slotID != 1)
+				{
+					if(!mergeItemStack(slotStack, 1, 2, false))
+					{
+						return ItemStack.EMPTY;
+					}
+				}
+				else {
+					if(!mergeItemStack(slotStack, 4, inventorySlots.size(), true))
+					{
+						return ItemStack.EMPTY;
+					}
+				}
+			}
+			else if(isInputItem(slotStack))
+			{
+				if(slotID != 0)
+				{
+					if(!mergeItemStack(slotStack, 0, 1, false))
+					{
+						return ItemStack.EMPTY;
+					}
+				}
+				else {
+					if(!mergeItemStack(slotStack, 4, inventorySlots.size(), true))
+					{
+						return ItemStack.EMPTY;
+					}
+				}
+			}
+			else {
+				if(slotID >= 4 && slotID <= 30)
+				{
+					if(!mergeItemStack(slotStack, 31, inventorySlots.size(), false))
+					{
+						return ItemStack.EMPTY;
+					}
+				}
+				else if(slotID > 30)
+				{
+					if(!mergeItemStack(slotStack, 4, 30, false))
+					{
+						return ItemStack.EMPTY;
+					}
+				}
+				else {
+					if(!mergeItemStack(slotStack, 4, inventorySlots.size(), true))
+					{
+						return ItemStack.EMPTY;
+					}
+				}
+			}
+
+			if(slotStack.getCount() == 0)
+			{
+				currentSlot.putStack(ItemStack.EMPTY);
+			}
+			else {
+				currentSlot.onSlotChanged();
+			}
+
+			if(slotStack.getCount() == stack.getCount())
+			{
+				return ItemStack.EMPTY;
+			}
+
+			currentSlot.onTake(player, slotStack);
+		}
+
+		return stack;
+	}
+
+	private boolean isInputItem(ItemStack itemstack)
+	{
+		for(Map.Entry<DoubleMachineInput, ItemStack> entry : ((Map<DoubleMachineInput, ItemStack>)tileEntity.getRecipes()).entrySet())
+		{
+			if(entry.getKey().itemStack.isItemEqual(itemstack))
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private boolean isExtraItem(ItemStack itemstack)
+	{
+		for(Map.Entry<DoubleMachineInput, ItemStack> entry : ((Map<DoubleMachineInput, ItemStack>)tileEntity.getRecipes()).entrySet())
+		{
+			if(entry.getKey().extraStack.isItemEqual(itemstack))
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
+}

--- a/src/main/java/mekanism/common/inventory/container/ContainerFactory.java
+++ b/src/main/java/mekanism/common/inventory/container/ContainerFactory.java
@@ -144,7 +144,7 @@ public class ContainerFactory extends Container
 					return ItemStack.EMPTY;
 				}
 			}
-			else if(tileEntity.recipeType.getAnyRecipe(slotStack, tileEntity.gasTank.getGasType(), tileEntity.infuseStored) != null)
+			else if(tileEntity.recipeType.getAnyRecipe(slotStack, inventorySlots.get(4).getStack(), tileEntity.gasTank.getGasType(), tileEntity.infuseStored) != null)
 			{
 				if(!isInputSlot(slotID))
 				{

--- a/src/main/java/mekanism/common/recipe/RecipeHandler.java
+++ b/src/main/java/mekanism/common/recipe/RecipeHandler.java
@@ -115,8 +115,10 @@ public final class RecipeHandler
 	 * Add a Combiner recipe.
 	 * @param input - input ItemStack
 	 * @param output - output ItemStack
+	 * @deprecated Replaced by {@link #addCombinerRecipe(ItemStack, ItemStack, ItemStack)}.
+	 * May be removed with Minecraft 1.13.
 	 */
-	@Deprecated // TODO remove this method in MC 1.13
+	@Deprecated
 	public static void addCombinerRecipe(ItemStack input, ItemStack output)
 	{
 		addRecipe(Recipe.COMBINER, new CombinerRecipe(input, output));

--- a/src/main/java/mekanism/common/recipe/RecipeHandler.java
+++ b/src/main/java/mekanism/common/recipe/RecipeHandler.java
@@ -116,7 +116,7 @@ public final class RecipeHandler
 	 * @param input - input ItemStack
 	 * @param output - output ItemStack
 	 */
-	@Deprecated
+	@Deprecated // TODO remove this method in MC 1.13
 	public static void addCombinerRecipe(ItemStack input, ItemStack output)
 	{
 		addRecipe(Recipe.COMBINER, new CombinerRecipe(input, output));

--- a/src/main/java/mekanism/common/recipe/RecipeHandler.java
+++ b/src/main/java/mekanism/common/recipe/RecipeHandler.java
@@ -13,6 +13,7 @@ import mekanism.api.infuse.InfuseType;
 import mekanism.common.block.states.BlockStateMachine.MachineType;
 import mekanism.common.recipe.inputs.AdvancedMachineInput;
 import mekanism.common.recipe.inputs.ChemicalPairInput;
+import mekanism.common.recipe.inputs.DoubleMachineInput;
 import mekanism.common.recipe.inputs.FluidInput;
 import mekanism.common.recipe.inputs.GasInput;
 import mekanism.common.recipe.inputs.InfusionInput;
@@ -29,6 +30,7 @@ import mekanism.common.recipe.machines.CombinerRecipe;
 import mekanism.common.recipe.machines.CrusherRecipe;
 import mekanism.common.recipe.machines.CrystallizerRecipe;
 import mekanism.common.recipe.machines.DissolutionRecipe;
+import mekanism.common.recipe.machines.DoubleMachineRecipe;
 import mekanism.common.recipe.machines.EnrichmentRecipe;
 import mekanism.common.recipe.machines.InjectionRecipe;
 import mekanism.common.recipe.machines.MachineRecipe;
@@ -114,9 +116,21 @@ public final class RecipeHandler
 	 * @param input - input ItemStack
 	 * @param output - output ItemStack
 	 */
+	@Deprecated
 	public static void addCombinerRecipe(ItemStack input, ItemStack output)
 	{
 		addRecipe(Recipe.COMBINER, new CombinerRecipe(input, output));
+	}
+
+	/**
+	 * Add a Combiner recipe.
+	 * @param input - input ItemStack
+	 * @param extra - extra ItemStack
+	 * @param output - output ItemStack
+	 */
+	public static void addCombinerRecipe(ItemStack input, ItemStack extra, ItemStack output)
+	{
+		addRecipe(Recipe.COMBINER, new CombinerRecipe(input, extra, output));
 	}
 
 	/**
@@ -445,6 +459,30 @@ public final class RecipeHandler
 		return null;
 	}
 
+
+	/**
+	 * Gets the DoubleMachineRecipe of the DoubleInput in the parameters, using the map in the paramaters.
+	 * @param input - DoubleInput
+	 * @param recipes - Map of recipes
+	 * @return DoubleMachineRecipe
+	 */
+	public static <RECIPE extends DoubleMachineRecipe<RECIPE>> RECIPE getRecipe(DoubleMachineInput input, Map<DoubleMachineInput, RECIPE> recipes)
+	{
+		if(input.isValid())
+		{
+			RECIPE recipe = recipes.get(input);
+
+			if(recipe == null)
+			{
+				recipe = recipes.get(input.wildCopy());
+			}
+
+			return recipe == null ? null : recipe.copy();
+		}
+
+		return null;
+	}
+
 	/**
 	 * Get the Electrolytic Separator Recipe corresponding to electrolysing a given fluid.
 	 * @param input - the FluidInput to electrolyse fluid from
@@ -580,7 +618,7 @@ public final class RecipeHandler
 		ENERGIZED_SMELTER(MachineType.ENERGIZED_SMELTER.blockName, ItemStackInput.class, ItemStackOutput.class, SmeltingRecipe.class),
 		ENRICHMENT_CHAMBER(MachineType.ENRICHMENT_CHAMBER.blockName, ItemStackInput.class, ItemStackOutput.class, EnrichmentRecipe.class),
 		OSMIUM_COMPRESSOR(MachineType.OSMIUM_COMPRESSOR.blockName, AdvancedMachineInput.class, ItemStackOutput.class, OsmiumCompressorRecipe.class),
-		COMBINER(MachineType.COMBINER.blockName, AdvancedMachineInput.class, ItemStackOutput.class, CombinerRecipe.class),
+		COMBINER(MachineType.COMBINER.blockName, DoubleMachineInput.class, ItemStackOutput.class, CombinerRecipe.class),
 		CRUSHER(MachineType.CRUSHER.blockName, ItemStackInput.class, ItemStackOutput.class, CrusherRecipe.class),
 		PURIFICATION_CHAMBER(MachineType.PURIFICATION_CHAMBER.blockName, AdvancedMachineInput.class, ItemStackOutput.class, PurificationRecipe.class),
 		METALLURGIC_INFUSER(MachineType.METALLURGIC_INFUSER.blockName, InfusionInput.class, ItemStackOutput.class, MetallurgicInfuserRecipe.class),

--- a/src/main/java/mekanism/common/recipe/inputs/DoubleMachineInput.java
+++ b/src/main/java/mekanism/common/recipe/inputs/DoubleMachineInput.java
@@ -17,9 +17,9 @@ public class DoubleMachineInput extends MachineInput<DoubleMachineInput>
 		itemStack = item;
 		extraStack = extra;
 	}
-	
+
 	public DoubleMachineInput() {}
-	
+
 	@Override
 	public void load(NBTTagCompound nbtTags)
 	{
@@ -47,10 +47,10 @@ public class DoubleMachineInput extends MachineInput<DoubleMachineInput>
 			{
 				inventory.set(index, StackUtils.subtract(inventory.get(index), stack));
 			}
-			
+
 			return true;
 		}
-		
+
 		return false;
 	}
 
@@ -83,7 +83,7 @@ public class DoubleMachineInput extends MachineInput<DoubleMachineInput>
 		{
 			return !other.isValid();
 		}
-		
+
 		return StackUtils.equalsWildcardWithNBT(itemStack, other.itemStack) && StackUtils.equalsWildcardWithNBT(extraStack, other.extraStack);
 	}
 

--- a/src/main/java/mekanism/common/recipe/inputs/DoubleMachineInput.java
+++ b/src/main/java/mekanism/common/recipe/inputs/DoubleMachineInput.java
@@ -1,0 +1,100 @@
+package mekanism.common.recipe.inputs;
+
+import mekanism.common.util.InventoryUtils;
+import mekanism.common.util.StackUtils;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.NonNullList;
+import net.minecraftforge.oredict.OreDictionary;
+
+public class DoubleMachineInput extends MachineInput<DoubleMachineInput>
+{
+	public ItemStack itemStack = ItemStack.EMPTY;
+	public ItemStack extraStack = ItemStack.EMPTY;
+
+	public DoubleMachineInput(ItemStack item, ItemStack extra)
+	{
+		itemStack = item;
+		extraStack = extra;
+	}
+	
+	public DoubleMachineInput() {}
+	
+	@Override
+	public void load(NBTTagCompound nbtTags)
+	{
+		itemStack = InventoryUtils.loadFromNBT(nbtTags.getCompoundTag("input"));
+		extraStack = InventoryUtils.loadFromNBT(nbtTags.getCompoundTag("extra"));
+	}
+
+	@Override
+	public DoubleMachineInput copy()
+	{
+		return new DoubleMachineInput(itemStack.copy(), extraStack.copy());
+	}
+
+	@Override
+	public boolean isValid()
+	{
+		return !itemStack.isEmpty() && !extraStack.isEmpty();
+	}
+
+	protected boolean useItemInternal(ItemStack stack, NonNullList<ItemStack> inventory, int index, boolean deplete)
+	{
+		if(inputContains(inventory.get(index), stack))
+		{
+			if(deplete)
+			{
+				inventory.set(index, StackUtils.subtract(inventory.get(index), stack));
+			}
+			
+			return true;
+		}
+		
+		return false;
+	}
+
+	public boolean useItem(NonNullList<ItemStack> inventory, int index, boolean deplete)
+	{
+		return useItemInternal(itemStack, inventory, index, deplete);
+	}
+
+	public boolean useExtra(NonNullList<ItemStack> inventory, int index, boolean deplete)
+	{
+		return useItemInternal(extraStack, inventory, index, deplete);
+	}
+
+	public boolean matches(DoubleMachineInput input)
+	{
+		return StackUtils.equalsWildcard(itemStack, input.itemStack) && input.itemStack.getCount() >= itemStack.getCount()
+				&& StackUtils.equalsWildcard(extraStack, input.extraStack) && input.extraStack.getCount() >= extraStack.getCount();
+	}
+
+	@Override
+	public int hashIngredients()
+	{
+		return StackUtils.hashItemStack(itemStack) ^ Integer.reverse(StackUtils.hashItemStack(extraStack));
+	}
+
+	@Override
+	public boolean testEquality(DoubleMachineInput other)
+	{
+		if(!isValid())
+		{
+			return !other.isValid();
+		}
+		
+		return StackUtils.equalsWildcardWithNBT(itemStack, other.itemStack) && StackUtils.equalsWildcardWithNBT(extraStack, other.extraStack);
+	}
+
+	@Override
+	public boolean isInstance(Object other)
+	{
+		return other instanceof DoubleMachineInput;
+	}
+
+	public DoubleMachineInput wildCopy()
+	{
+		return new DoubleMachineInput(new ItemStack(itemStack.getItem(), itemStack.getCount(), OreDictionary.WILDCARD_VALUE), new ItemStack(extraStack.getItem(), extraStack.getCount(), OreDictionary.WILDCARD_VALUE));
+	}
+}

--- a/src/main/java/mekanism/common/recipe/machines/CombinerRecipe.java
+++ b/src/main/java/mekanism/common/recipe/machines/CombinerRecipe.java
@@ -1,20 +1,26 @@
 package mekanism.common.recipe.machines;
 
-import mekanism.common.MekanismFluids;
-import mekanism.common.recipe.inputs.AdvancedMachineInput;
+import mekanism.common.recipe.inputs.DoubleMachineInput;
 import mekanism.common.recipe.outputs.ItemStackOutput;
+import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 
-public class CombinerRecipe extends AdvancedMachineRecipe<CombinerRecipe>
+public class CombinerRecipe extends DoubleMachineRecipe<CombinerRecipe>
 {
-	public CombinerRecipe(AdvancedMachineInput input, ItemStackOutput output)
+	public CombinerRecipe(DoubleMachineInput input, ItemStackOutput output)
 	{
 		super(input, output);
 	}
 
+	public CombinerRecipe(ItemStack input, ItemStack extra, ItemStack output)
+	{
+		super(input, extra, output);
+	}
+
+	@Deprecated
 	public CombinerRecipe(ItemStack input, ItemStack output)
 	{
-		super(input, MekanismFluids.LiquidStone, output);
+		super(input, new ItemStack(Blocks.COBBLESTONE), output);
 	}
 
 	@Override

--- a/src/main/java/mekanism/common/recipe/machines/CombinerRecipe.java
+++ b/src/main/java/mekanism/common/recipe/machines/CombinerRecipe.java
@@ -17,7 +17,11 @@ public class CombinerRecipe extends DoubleMachineRecipe<CombinerRecipe>
 		super(input, extra, output);
 	}
 
-	@Deprecated // TODO remove this method in MC 1.13
+	/**
+	 * @deprecated Replaced by {@link #CombinerRecipe(ItemStack, ItemStack, ItemStack)}.
+	 * May be removed with Minecraft 1.13.
+	 */
+	@Deprecated
 	public CombinerRecipe(ItemStack input, ItemStack output)
 	{
 		super(input, new ItemStack(Blocks.COBBLESTONE), output);

--- a/src/main/java/mekanism/common/recipe/machines/CombinerRecipe.java
+++ b/src/main/java/mekanism/common/recipe/machines/CombinerRecipe.java
@@ -17,7 +17,7 @@ public class CombinerRecipe extends DoubleMachineRecipe<CombinerRecipe>
 		super(input, extra, output);
 	}
 
-	@Deprecated
+	@Deprecated // TODO remove this method in MC 1.13
 	public CombinerRecipe(ItemStack input, ItemStack output)
 	{
 		super(input, new ItemStack(Blocks.COBBLESTONE), output);

--- a/src/main/java/mekanism/common/recipe/machines/DoubleMachineRecipe.java
+++ b/src/main/java/mekanism/common/recipe/machines/DoubleMachineRecipe.java
@@ -1,0 +1,32 @@
+package mekanism.common.recipe.machines;
+
+import mekanism.common.recipe.inputs.DoubleMachineInput;
+import mekanism.common.recipe.outputs.ItemStackOutput;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.NonNullList;
+
+public abstract class DoubleMachineRecipe<RECIPE extends DoubleMachineRecipe<RECIPE>> extends MachineRecipe<DoubleMachineInput, ItemStackOutput, RECIPE>
+{
+	public DoubleMachineRecipe(DoubleMachineInput input, ItemStackOutput output)
+	{
+		super(input, output);
+	}
+
+	public DoubleMachineRecipe(ItemStack input, ItemStack extra, ItemStack output)
+	{
+		this(new DoubleMachineInput(input, extra), new ItemStackOutput(output));
+	}
+
+	public boolean canOperate(NonNullList<ItemStack> inventory, int inputIndex, int extraIndex, int outputIndex)
+	{
+		return getInput().useItem(inventory, inputIndex, false) && getInput().useExtra(inventory, extraIndex, false) && getOutput().applyOutputs(inventory, outputIndex, false);
+	}
+
+	public void operate(NonNullList<ItemStack> inventory, int inputIndex, int extraIndex, int outputIndex)
+	{
+		if(getInput().useItem(inventory, inputIndex, true) && getInput().useExtra(inventory, extraIndex, true))
+		{
+			getOutput().applyOutputs(inventory, outputIndex, true);
+		}
+	}
+}

--- a/src/main/java/mekanism/common/tile/TileEntityCombiner.java
+++ b/src/main/java/mekanism/common/tile/TileEntityCombiner.java
@@ -2,47 +2,23 @@ package mekanism.common.tile;
 
 import java.util.Map;
 
-import mekanism.api.gas.Gas;
-import mekanism.api.gas.GasStack;
-import mekanism.common.MekanismFluids;
 import mekanism.common.block.states.BlockStateMachine;
 import mekanism.common.config.MekanismConfig.usage;
 import mekanism.common.recipe.RecipeHandler.Recipe;
-import mekanism.common.recipe.inputs.AdvancedMachineInput;
+import mekanism.common.recipe.inputs.DoubleMachineInput;
 import mekanism.common.recipe.machines.CombinerRecipe;
-import mekanism.common.tile.prefab.TileEntityAdvancedElectricMachine;
-import net.minecraft.block.Block;
-import net.minecraft.init.Blocks;
-import net.minecraft.item.ItemBlock;
-import net.minecraft.item.ItemStack;
+import mekanism.common.tile.prefab.TileEntityDoubleElectricMachine;
 
-public class TileEntityCombiner extends TileEntityAdvancedElectricMachine<CombinerRecipe>
+public class TileEntityCombiner extends TileEntityDoubleElectricMachine<CombinerRecipe>
 {
 	public TileEntityCombiner()
 	{
-		super("combiner", "Combiner", BlockStateMachine.MachineType.COMBINER.baseEnergy, usage.combinerUsage, 200, 1);
+		super("combiner", "Combiner", BlockStateMachine.MachineType.COMBINER.baseEnergy, usage.combinerUsage, 200);
 	}
 
 	@Override
-	public Map<AdvancedMachineInput, CombinerRecipe> getRecipes()
+	public Map<DoubleMachineInput, CombinerRecipe> getRecipes()
 	{
 		return Recipe.COMBINER.get();
-	}
-
-	@Override
-	public GasStack getItemGas(ItemStack itemstack)
-	{
-		if(itemstack.getItem() instanceof ItemBlock && Block.getBlockFromItem(itemstack.getItem()) == Blocks.COBBLESTONE)
-		{
-			return new GasStack(MekanismFluids.LiquidStone, 200);
-		}
-
-		return null;
-	}
-
-	@Override
-	public boolean isValidGas(Gas gas)
-	{
-		return false;
 	}
 }

--- a/src/main/java/mekanism/common/tile/prefab/TileEntityDoubleElectricMachine.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityDoubleElectricMachine.java
@@ -1,0 +1,287 @@
+package mekanism.common.tile.prefab;
+
+import mekanism.api.EnumColor;
+import mekanism.api.transmitters.TransmissionType;
+import mekanism.common.MekanismBlocks;
+import mekanism.common.MekanismItems;
+import mekanism.common.SideData;
+import mekanism.common.Tier.BaseTier;
+import mekanism.common.Upgrade;
+import mekanism.common.base.IFactory.RecipeType;
+import mekanism.common.base.ITierUpgradeable;
+import mekanism.common.recipe.RecipeHandler;
+import mekanism.common.recipe.inputs.DoubleMachineInput;
+import mekanism.common.recipe.machines.DoubleMachineRecipe;
+import mekanism.common.recipe.outputs.ItemStackOutput;
+import mekanism.common.tile.TileEntityFactory;
+import mekanism.common.tile.component.TileComponentConfig;
+import mekanism.common.tile.component.TileComponentEjector;
+import mekanism.common.util.ChargeUtils;
+import mekanism.common.util.InventoryUtils;
+import mekanism.common.util.MekanismUtils;
+import mekanism.common.util.MekanismUtils.ResourceType;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.NonNullList;
+
+public abstract class TileEntityDoubleElectricMachine<RECIPE extends DoubleMachineRecipe<RECIPE>> extends TileEntityBasicMachine<DoubleMachineInput, ItemStackOutput, RECIPE> implements ITierUpgradeable
+{
+	/**
+	 * Double Electric Machine -- a machine like this has a total of 4 slots. Input slot (0), secondary slot (1), output slot (2),
+	 * energy slot (3), and the upgrade slot (4). The machine will not run if it does not have enough electricity.
+	 *
+	 * @param soundPath - location of the sound effect
+	 * @param name - full name of this machine
+	 * @param maxEnergy - maximum amount of energy this machine can hold.
+	 * @param baseEnergyUsage - how much energy this machine uses per tick.
+	 * @param ticksRequired - how many ticks it takes to smelt an item.
+	 */
+	public TileEntityDoubleElectricMachine(String soundPath, String name, double maxEnergy, double baseEnergyUsage, int ticksRequired)
+	{
+		super(soundPath, name, maxEnergy, baseEnergyUsage, 4, ticksRequired, MekanismUtils.getResource(ResourceType.GUI, "guibasicmachine.png"));
+
+		configComponent = new TileComponentConfig(this, TransmissionType.ITEM, TransmissionType.ENERGY);
+		
+		configComponent.addOutput(TransmissionType.ITEM, new SideData("None", EnumColor.GREY, InventoryUtils.EMPTY));
+		configComponent.addOutput(TransmissionType.ITEM, new SideData("Input", EnumColor.DARK_RED, new int[] {0}));
+		configComponent.addOutput(TransmissionType.ITEM, new SideData("Output", EnumColor.DARK_BLUE, new int[] {2}));
+		configComponent.addOutput(TransmissionType.ITEM, new SideData("Energy", EnumColor.DARK_GREEN, new int[] {3}));
+		configComponent.addOutput(TransmissionType.ITEM, new SideData("Extra", EnumColor.PURPLE, new int[] {1}));
+
+		configComponent.setConfig(TransmissionType.ITEM, new byte[] {4, 1, 0, 3, 0, 2});
+		configComponent.setInputConfig(TransmissionType.ENERGY);
+
+		inventory = NonNullList.withSize(5, ItemStack.EMPTY);
+
+		ejectorComponent = new TileComponentEjector(this);
+		ejectorComponent.setOutputData(TransmissionType.ITEM, configComponent.getOutputs(TransmissionType.ITEM).get(2));
+	}
+	
+	@Override
+	public boolean upgrade(BaseTier upgradeTier)
+	{
+		if(upgradeTier != BaseTier.BASIC)
+		{
+			return false;
+		}
+		
+		world.setBlockToAir(getPos());
+		world.setBlockState(getPos(), MekanismBlocks.MachineBlock.getStateFromMeta(5), 3);
+		
+		TileEntityFactory factory = (TileEntityFactory)world.getTileEntity(getPos());
+		RecipeType type = RecipeType.getFromMachine(getBlockType(), getBlockMetadata());
+		
+		//Basic
+		factory.facing = facing;
+		factory.clientFacing = clientFacing;
+		factory.ticker = ticker;
+		factory.redstone = redstone;
+		factory.redstoneLastTick = redstoneLastTick;
+		factory.doAutoSync = doAutoSync;
+		
+		//Electric
+		factory.electricityStored = electricityStored;
+
+		//Noisy
+		factory.soundURL = soundURL;
+		
+		//Machine
+		factory.progress[0] = operatingTicks;
+		factory.updateDelay = updateDelay;
+		factory.isActive = isActive;
+		factory.clientActive = clientActive;
+		factory.controlType = controlType;
+		factory.prevEnergy = prevEnergy;
+		factory.upgradeComponent.readFrom(upgradeComponent);
+		factory.upgradeComponent.setUpgradeSlot(0);
+		factory.ejectorComponent.readFrom(ejectorComponent);
+		factory.ejectorComponent.setOutputData(TransmissionType.ITEM, factory.configComponent.getOutputs(TransmissionType.ITEM).get(2));
+		factory.recipeType = type;
+		factory.upgradeComponent.setSupported(Upgrade.GAS, type.fuelEnergyUpgrades());
+		factory.securityComponent.readFrom(securityComponent);
+		
+		for(TransmissionType transmission : configComponent.transmissions)
+		{
+			factory.configComponent.setConfig(transmission, configComponent.getConfig(transmission).asByteArray());
+			factory.configComponent.setEjecting(transmission, configComponent.isEjecting(transmission));
+		}
+		
+		//Double Machine
+		factory.inventory.set(5, inventory.get(0));
+		factory.inventory.set(4, inventory.get(1));
+		factory.inventory.set(5+3, inventory.get(2));
+		factory.inventory.set(1, inventory.get(3));
+		factory.inventory.set(0, inventory.get(4));
+		
+		for(Upgrade upgrade : factory.upgradeComponent.getSupportedTypes())
+		{
+			factory.recalculateUpgradables(upgrade);
+		}
+		
+		factory.upgraded = true;
+		factory.markDirty();
+		
+		return true;
+	}
+
+	@Override
+	public void onUpdate()
+	{
+		super.onUpdate();
+
+		if(!world.isRemote)
+		{
+			ChargeUtils.discharge(3, this);
+
+			boolean inactive = false;
+
+			RECIPE recipe = getRecipe();
+			if(canOperate(recipe) && MekanismUtils.canFunction(this) && getEnergy() >= energyPerTick)
+			{
+				setActive(true);
+
+				operatingTicks++;
+
+				if(operatingTicks >= ticksRequired)
+				{
+					operate(recipe);
+
+					operatingTicks = 0;
+				}
+
+				electricityStored -= energyPerTick;
+			}
+			else {
+				inactive = true;
+				setActive(false);
+			}
+
+			if(inactive && getRecipe() == null)
+			{
+				operatingTicks = 0;
+			}
+
+			prevEnergy = getEnergy();
+		}
+	}
+
+	@Override
+	public boolean isItemValidForSlot(int slotID, ItemStack itemstack)
+	{
+		if(slotID == 2)
+		{
+			return false;
+		}
+		else if(slotID == 4)
+		{
+			return itemstack.getItem() == MekanismItems.SpeedUpgrade || itemstack.getItem() == MekanismItems.EnergyUpgrade;
+		}
+		else if(slotID == 0)
+		{
+			for(DoubleMachineInput input : getRecipes().keySet())
+			{
+				if(input.itemStack.isItemEqual(itemstack))
+				{
+					return true;
+				}
+			}
+		}
+		else if(slotID == 3)
+		{
+			return ChargeUtils.canBeDischarged(itemstack);
+		}
+		else if(slotID == 1)
+		{
+			for(DoubleMachineInput input : getRecipes().keySet())
+			{
+				if(input.extraStack.isItemEqual(itemstack))
+				{
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	@Override
+	public DoubleMachineInput getInput()
+	{
+		return new DoubleMachineInput(inventory.get(0), inventory.get(1));
+	}
+
+	@Override
+	public RECIPE getRecipe()
+	{
+		DoubleMachineInput input = getInput();
+
+		if(cachedRecipe == null || !input.testEquality(cachedRecipe.getInput()))
+		{
+			cachedRecipe = RecipeHandler.getRecipe(input, getRecipes());
+		}
+
+		return cachedRecipe;
+	}
+
+	@Override
+	public void operate(RECIPE recipe)
+	{
+		recipe.operate(inventory, 0, 1, 2);
+
+		markDirty();
+		ejectorComponent.outputItems();
+	}
+
+	@Override
+	public boolean canOperate(RECIPE recipe)
+	{
+		return recipe != null && recipe.canOperate(inventory, 0, 1, 2);
+	}
+
+	@Override
+	public boolean canExtractItem(int slotID, ItemStack itemstack, EnumFacing side)
+	{
+		if(slotID == 3)
+		{
+			return ChargeUtils.canBeOutputted(itemstack, false);
+		}
+		else if(slotID == 2)
+		{
+			return true;
+		}
+
+		return false;
+	}
+
+	private static final String[] methods = new String[] {"getEnergy", "getProgress", "isActive", "facing", "canOperate", "getMaxEnergy", "getEnergyNeeded"};
+
+	@Override
+	public String[] getMethods()
+	{
+		return methods;
+	}
+
+	@Override
+	public Object[] invoke(int method, Object[] arguments) throws Exception
+	{
+		switch(method)
+		{
+			case 0:
+				return new Object[] {getEnergy()};
+			case 1:
+				return new Object[] {operatingTicks};
+			case 2:
+				return new Object[] {isActive};
+			case 3:
+				return new Object[] {facing};
+			case 4:
+				return new Object[] {canOperate(RecipeHandler.getRecipe(getInput(), getRecipes()))};
+			case 5:
+				return new Object[] {maxEnergy};
+			case 6:
+				return new Object[] {maxEnergy-getEnergy()};
+			default:
+				throw new NoSuchMethodException();
+		}
+	}
+}

--- a/src/main/java/mekanism/common/tile/prefab/TileEntityDoubleElectricMachine.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityDoubleElectricMachine.java
@@ -41,7 +41,7 @@ public abstract class TileEntityDoubleElectricMachine<RECIPE extends DoubleMachi
 		super(soundPath, name, maxEnergy, baseEnergyUsage, 4, ticksRequired, MekanismUtils.getResource(ResourceType.GUI, "guibasicmachine.png"));
 
 		configComponent = new TileComponentConfig(this, TransmissionType.ITEM, TransmissionType.ENERGY);
-		
+
 		configComponent.addOutput(TransmissionType.ITEM, new SideData("None", EnumColor.GREY, InventoryUtils.EMPTY));
 		configComponent.addOutput(TransmissionType.ITEM, new SideData("Input", EnumColor.DARK_RED, new int[] {0}));
 		configComponent.addOutput(TransmissionType.ITEM, new SideData("Output", EnumColor.DARK_BLUE, new int[] {2}));
@@ -56,7 +56,7 @@ public abstract class TileEntityDoubleElectricMachine<RECIPE extends DoubleMachi
 		ejectorComponent = new TileComponentEjector(this);
 		ejectorComponent.setOutputData(TransmissionType.ITEM, configComponent.getOutputs(TransmissionType.ITEM).get(2));
 	}
-	
+
 	@Override
 	public boolean upgrade(BaseTier upgradeTier)
 	{
@@ -64,13 +64,13 @@ public abstract class TileEntityDoubleElectricMachine<RECIPE extends DoubleMachi
 		{
 			return false;
 		}
-		
+
 		world.setBlockToAir(getPos());
 		world.setBlockState(getPos(), MekanismBlocks.MachineBlock.getStateFromMeta(5), 3);
-		
+
 		TileEntityFactory factory = (TileEntityFactory)world.getTileEntity(getPos());
 		RecipeType type = RecipeType.getFromMachine(getBlockType(), getBlockMetadata());
-		
+
 		//Basic
 		factory.facing = facing;
 		factory.clientFacing = clientFacing;
@@ -78,13 +78,13 @@ public abstract class TileEntityDoubleElectricMachine<RECIPE extends DoubleMachi
 		factory.redstone = redstone;
 		factory.redstoneLastTick = redstoneLastTick;
 		factory.doAutoSync = doAutoSync;
-		
+
 		//Electric
 		factory.electricityStored = electricityStored;
 
 		//Noisy
 		factory.soundURL = soundURL;
-		
+
 		//Machine
 		factory.progress[0] = operatingTicks;
 		factory.updateDelay = updateDelay;
@@ -99,28 +99,28 @@ public abstract class TileEntityDoubleElectricMachine<RECIPE extends DoubleMachi
 		factory.recipeType = type;
 		factory.upgradeComponent.setSupported(Upgrade.GAS, type.fuelEnergyUpgrades());
 		factory.securityComponent.readFrom(securityComponent);
-		
+
 		for(TransmissionType transmission : configComponent.transmissions)
 		{
 			factory.configComponent.setConfig(transmission, configComponent.getConfig(transmission).asByteArray());
 			factory.configComponent.setEjecting(transmission, configComponent.isEjecting(transmission));
 		}
-		
+
 		//Double Machine
 		factory.inventory.set(5, inventory.get(0));
 		factory.inventory.set(4, inventory.get(1));
 		factory.inventory.set(5+3, inventory.get(2));
 		factory.inventory.set(1, inventory.get(3));
 		factory.inventory.set(0, inventory.get(4));
-		
+
 		for(Upgrade upgrade : factory.upgradeComponent.getSupportedTypes())
 		{
 			factory.recalculateUpgradables(upgrade);
 		}
-		
+
 		factory.upgraded = true;
 		factory.markDirty();
-		
+
 		return true;
 	}
 

--- a/src/main/resources/assets/mekanism/lang/cs_cz.lang
+++ b/src/main/resources/assets/mekanism/lang/cs_cz.lang
@@ -291,7 +291,6 @@ gas.sulfurTrioxideGas=Oxid Sírový
 gas.sulfuricAcid=Kyselina Sírová
 gas.hydrogenChloride=Chlorid Vodnatý
 gas.liquidOsmium=Tekuté Osmium
-gas.liquidStone=Tekutý Kámen
 gas.ethene=Ethylen
 gas.sodium=Sodík
 gas.brine=Plynná Solanka

--- a/src/main/resources/assets/mekanism/lang/da_dk.lang
+++ b/src/main/resources/assets/mekanism/lang/da_dk.lang
@@ -290,7 +290,6 @@ gas.sulfurTrioxideGas=Svovltrioxid
 gas.sulfuricAcid=Svovlsyre
 gas.hydrogenChloride=Hydrogenklorid
 gas.liquidOsmium=Flydende Osmium
-gas.liquidStone=Flydende Sten
 gas.ethene=Ethen
 gas.sodium=Natrium
 gas.brine=Saltlage i Gasform

--- a/src/main/resources/assets/mekanism/lang/de_de.lang
+++ b/src/main/resources/assets/mekanism/lang/de_de.lang
@@ -291,7 +291,6 @@ gas.sulfurTrioxideGas=Schwefeltrioxid
 gas.sulfuricAcid=Schwefelsäure
 gas.hydrogenChloride=Chlorwasserstoff
 gas.liquidOsmium=Flüssiges Osmium
-gas.liquidStone=Flüssiges Gestein
 gas.ethene=Ethylen
 gas.sodium=Natrium
 gas.brine=Gasförmiges Salzwasser

--- a/src/main/resources/assets/mekanism/lang/en_us.lang
+++ b/src/main/resources/assets/mekanism/lang/en_us.lang
@@ -305,7 +305,6 @@ gas.sulfurtrioxide=Sulfur Trioxide
 gas.sulfuricacid=Sulfuric Acid
 gas.hydrogenchloride=Hydrogen Chloride
 gas.liquidosmium=Liquid Osmium
-gas.liquidstone=Liquid Stone
 gas.ethene=Ethylene
 gas.sodium=Sodium
 gas.brine=Gaseous Brine

--- a/src/main/resources/assets/mekanism/lang/fr_fr.lang
+++ b/src/main/resources/assets/mekanism/lang/fr_fr.lang
@@ -290,7 +290,6 @@ gas.sulfurTrioxideGas=Trioxyde de souffre
 gas.sulfuricAcid=Acide sulfurique gazeux
 gas.hydrogenChloride=Chlorure d'hydrogène gazeux
 gas.liquidOsmium=Osmium liquide
-gas.liquidStone=Pierre liquide
 gas.ethene=Ethylène
 gas.sodium=Sodium gazeux
 gas.brine=Saumure gazeuse

--- a/src/main/resources/assets/mekanism/lang/it_it.lang
+++ b/src/main/resources/assets/mekanism/lang/it_it.lang
@@ -265,7 +265,6 @@ gas.sulfurTrioxideGas=Triossido di zolfo
 gas.sulfuricAcid=Acido solforico
 gas.hydrogenChloride=Cloruro di idrogeno
 gas.liquidOsmium=Osmio liquido
-gas.liquidStone=Pietra liquida
 gas.ethene=Etilene
 gas.sodium=Sodio
 gas.brine=Salamoia gassosa

--- a/src/main/resources/assets/mekanism/lang/ja_jp.lang
+++ b/src/main/resources/assets/mekanism/lang/ja_jp.lang
@@ -291,7 +291,6 @@ gas.sulfurTrioxideGas=三酸化硫黄
 gas.sulfuricAcid=硫酸
 gas.hydrogenChloride=塩化水素
 gas.liquidOsmium=オスミウム
-gas.liquidStone=石
 gas.ethene=エチレン
 gas.sodium=ナトリウム
 gas.brine=気化した鹹水

--- a/src/main/resources/assets/mekanism/lang/ko_kr.lang
+++ b/src/main/resources/assets/mekanism/lang/ko_kr.lang
@@ -232,7 +232,6 @@ gas.sulfurTrioxideGas=산산화 황
 gas.sulfuricAcid=황산
 gas.hydrogenChloride=염화 수소
 gas.liquidOsmium=액화 오스뮴
-gas.liquidStone=액화 돌
 gas.ethene=에틸렌
 gas.sodium=나트륨
 gas.brine=기체 소금물

--- a/src/main/resources/assets/mekanism/lang/no_no.lang
+++ b/src/main/resources/assets/mekanism/lang/no_no.lang
@@ -259,7 +259,6 @@ gas.sulfurTrioxideGas=Svoveltrioksyd
 gas.sulfuricAcid=Svovelsyre
 gas.hydrogenChloride=Hydrogenklorid
 gas.liquidOsmium=Flytende Osmium
-gas.liquidStone=Flytende Stein
 gas.ethene=Etylen
 gas.sodium=Natrium
 gas.brine=Brine i gassform

--- a/src/main/resources/assets/mekanism/lang/pl_pl.lang
+++ b/src/main/resources/assets/mekanism/lang/pl_pl.lang
@@ -192,7 +192,6 @@ gas.sulfurTrioxideGas=Trójtlenek siarki
 gas.sulfuricAcid=Kwas siarkowy
 gas.hydrogenChloride=Chlorowodór
 gas.liquidOsmium=Płynny osm
-gas.liquidStone=Płynny kamień
 
 gas.iron=Zawiesina żelaza
 gas.gold=Zawiesina złota

--- a/src/main/resources/assets/mekanism/lang/pt_br.lang
+++ b/src/main/resources/assets/mekanism/lang/pt_br.lang
@@ -291,7 +291,6 @@ gas.sulfurTrioxideGas=Trióxido de Enxofre
 gas.sulfuricAcid=Ácido Sulfúrico
 gas.hydrogenChloride=Cloreto de Hidrogênio
 gas.liquidOsmium=Ósmio Líquido
-gas.liquidStone=Pedra Líquida
 gas.ethene=Etileno
 gas.sodium=Sódio
 gas.brine=Salmoura Gasosa

--- a/src/main/resources/assets/mekanism/lang/pt_pt.lang
+++ b/src/main/resources/assets/mekanism/lang/pt_pt.lang
@@ -291,7 +291,6 @@ gas.sulfurTrioxideGas=Trióxido de Enxofre
 gas.sulfuricAcid=Ácido Sulfúrico
 gas.hydrogenChloride=Cloreto de Hidrogénio
 gas.liquidOsmium=Ósmio Líquido
-gas.liquidStone=Pedra Líquida
 gas.ethene=Etileno
 gas.sodium=Sódio
 gas.brine=Salmoura Gasosa

--- a/src/main/resources/assets/mekanism/lang/ru_ru.lang
+++ b/src/main/resources/assets/mekanism/lang/ru_ru.lang
@@ -296,7 +296,6 @@ gas.sulfurtrioxide=Триоксид серы
 gas.sulfuricacid=Серная кислота
 gas.hydrogenchloride=Хлороводород
 gas.liquidosmium=Жидкий осмий
-gas.liquidstone=Разжиженный камень
 gas.ethene=Этилен
 gas.sodium=Натрий
 gas.brine=Газообразный рассол

--- a/src/main/resources/assets/mekanism/lang/zh_cn.lang
+++ b/src/main/resources/assets/mekanism/lang/zh_cn.lang
@@ -296,7 +296,6 @@ gas.sulfurTrioxideGas=三氧化硫
 gas.sulfuricAcid=硫酸
 gas.hydrogenChloride=氯化氢
 gas.liquidOsmium=液态锇
-gas.liquidStone=液态石头
 gas.ethene=乙烯
 gas.sodium=钠
 gas.brine=气态盐水

--- a/src/main/resources/assets/mekanism/lang/zh_tw.lang
+++ b/src/main/resources/assets/mekanism/lang/zh_tw.lang
@@ -259,7 +259,6 @@ gas.sulfurTrioxideGas=三氧化硫
 gas.sulfuricAcid=硫酸
 gas.hydrogenChloride=氯化氫
 gas.liquidOsmium=液態鋨
-gas.liquidStone=液態石頭
 gas.ethene=乙烯
 gas.sodium=鈉
 gas.brine=氣態鹽水


### PR DESCRIPTION
This lets us combine netherrack with quartz to make nether quartz ore now, and can be extended to combine any two arbitrary items. Note the following two (rather minor) breaking changes:
1. Cobblestone used to be consumed at the beginning of work. It's now consumed at the end. Any combiners that were running prior to this update will lose the single piece of cobblestone that they had consumed but not yet finished using.
2. Any CraftTweaker scripts that used the three-argument form of `mods.mekanism.combiner.addRecipe` (passing `<gas:liquidStone>` as the second argument) will break.