### PR TITLE
Added subtype check to transporter finder

### DIFF
--- a/src/main/java/mekanism/common/content/transporter/Finder.java
+++ b/src/main/java/mekanism/common/content/transporter/Finder.java
@@ -87,7 +87,7 @@ public abstract class Finder
 		@Override
 		public boolean modifies(ItemStack stack)
 		{
-			return StackUtils.equalsWildcard(itemType, stack);
+			return itemType.getHasSubtypes() ? StackUtils.equalsWildcard(itemType, stack) : itemType.getItem() == stack.getItem();
 		}
 	}
 	


### PR DESCRIPTION
Added an extra sybtype check to the transporter finder, just like # 992
Fixes #4694