### PR TITLE
Make electrolytic separator not so efficient.

### DIFF
--- a/src/main/java/mekanism/common/tile/TileEntityElectrolyticSeparator.java
+++ b/src/main/java/mekanism/common/tile/TileEntityElectrolyticSeparator.java
@@ -646,4 +646,21 @@ public class TileEntityElectrolyticSeparator extends TileEntityMachine implement
 	{
 		return new Object[] {fluidTank, leftTank, rightTank};
 	}
+
+	@Override
+	public void recalculateUpgradables(Upgrade upgrade)
+	{
+		super.recalculateUpgradables(upgrade);
+
+		switch(upgrade)
+		{
+			case ENERGY:
+				maxEnergy = MekanismUtils.getMaxEnergy(this, BASE_MAX_ENERGY);
+				energyPerTick = BlockStateMachine.MachineType.ELECTROLYTIC_SEPARATOR.getUsage();
+				setEnergy(Math.min(getMaxEnergy(), getEnergy()));
+				break;
+			default:
+				break;
+		}
+	}
 }


### PR DESCRIPTION
Force the energy usage to be a constant and not modified by any electrical upgrades.
Fixes #4852