### PR TITLE
work on buildcraft

### DIFF
--- a/src/main/java/mekanism/common/integration/MekanismHooks.java
+++ b/src/main/java/mekanism/common/integration/MekanismHooks.java
@@ -102,6 +102,10 @@ public final class MekanismHooks
 		{
 			loadCCPeripheralProviders();
 		}
+		
+		if (AE2Loaded){
+			registerAE2Recipes();
+		}
 
 		if(Loader.isModLoaded("crafttweaker"))
 		{
@@ -109,10 +113,6 @@ public final class MekanismHooks
 		}
 
 		Wrenches.initialise();
-
-		if (AE2Loaded){
-			registerAE2Recipes();
-		}
 	}
 
 	@Method(modid = MekanismHooks.IC2_MOD_ID)


### PR DESCRIPTION
want the Universal Cable to work whit buildcraft when they are moving back to MJ and don't get a simple way to keep all MJ you get over without a convertor and it's not simple to get a cnvertor mod to work whit 1.12.2
 