### PR TITLE
Removed markDirty() call from TileEntityBasicBlock::onChunkLoad

### DIFF
--- a/src/main/java/mekanism/common/tile/prefab/TileEntityBasicBlock.java
+++ b/src/main/java/mekanism/common/tile/prefab/TileEntityBasicBlock.java
@@ -105,7 +105,7 @@ public abstract class TileEntityBasicBlock extends TileEntity implements ITileNe
 	@Override
 	public void onChunkLoad()
 	{
-		markDirty();
+		
 	}
 
 	public void open(EntityPlayer player)


### PR DESCRIPTION
Resolves xnet compatibility issue wherein an xnet cable touching a mekanism machine in a chunk loaded area may corrupt all xnet networks server-wide on server restart.

as per https://github.com/aidancbrady/Mekanism/issues/5104 and https://github.com/McJtyMods/XNet/issues/283
