### PR TITLE
fix root cause of #5146 (mining wizardry wisdom wood logs with atomic disassembler)

### DIFF
--- a/src/main/java/mekanism/common/item/ItemAtomicDisassembler.java
+++ b/src/main/java/mekanism/common/item/ItemAtomicDisassembler.java
@@ -160,7 +160,7 @@ public class ItemAtomicDisassembler extends ItemEnergized
 
 			if(getMode(itemstack) == 3 && isOre && !player.capabilities.isCreativeMode)
 			{
-				Set<Coord4D> found = new Finder(player.world, stack, new Coord4D(pos, player.world), raytrace).calc();
+				Set<Coord4D> found = new Finder(player.world, stack, new Coord4D(pos, player.world), raytrace, player).calc();
 
 				for(Coord4D coord : found)
 				{
@@ -389,13 +389,16 @@ public class ItemAtomicDisassembler extends ItemEnergized
 		
 		RayTraceResult rayTraceResult;
 
-		public Finder(World w, ItemStack s, Coord4D loc, RayTraceResult traceResult)
+		EntityPlayer player;
+
+		public Finder(World w, ItemStack s, Coord4D loc, RayTraceResult traceResult, EntityPlayer p)
 		{
 			world = w;
 			stack = s;
 			location = loc;
 			startBlock = loc.getBlock(w);
 			rayTraceResult = traceResult;
+			player = p;
 		}
 
 		public void loop(Coord4D pointer)
@@ -411,7 +414,7 @@ public class ItemAtomicDisassembler extends ItemEnergized
 			{
 				Coord4D coord = pointer.offset(side);
 
-				ItemStack blockStack = coord.getBlock(world).getPickBlock(coord.getBlockState(world), rayTraceResult, world, coord.getPos(), null);
+				ItemStack blockStack = coord.getBlock(world).getPickBlock(coord.getBlockState(world), rayTraceResult, world, coord.getPos(), player);
 
 				if(coord.exists(world) && checkID(coord.getBlock(world)) && (stack.isItemEqual(blockStack) || (coord.getBlock(world) == startBlock && MekanismUtils.getOreDictName(stack).contains("logWood") && coord.getBlockMeta(world) % 4 == stack.getItemDamage() % 4)))
 				{


### PR DESCRIPTION
As mentioned in #5146, the getPickBlock method used in the finder class for the atomic disassembler passes a null argument for the player.  Although this normally works, it is possible for the block to override the method in a way that breaks it.  This was the case in Wizardry and may still be a problem with other mods.  I've modified the code so that it passes the player object of the player who is using the disassembler.  