### PR TITLE
Clamp power to max values rather than letting it wrap

### DIFF
--- a/src/main/java/mekanism/common/integration/forgeenergy/ForgeEnergyItemWrapper.java
+++ b/src/main/java/mekanism/common/integration/forgeenergy/ForgeEnergyItemWrapper.java
@@ -58,16 +58,25 @@ public class ForgeEnergyItemWrapper extends ItemCapability implements IEnergySto
 		return 0;
 	}
 
+	private static int clampToInt(double d) {
+		// Not using Math.min because it makes you cast things wrong
+		if(d < Integer.MAX_VALUE) {
+			return (int)d;
+		} else {
+			return Integer.MAX_VALUE;
+		}
+	}
+
 	@Override
 	public int getEnergyStored() 
 	{
-		return (int)Math.round(getItem().getEnergy(getStack())*general.TO_FORGE);
+		return clampToInt(Math.round(getItem().getEnergy(getStack())*general.TO_FORGE));
 	}
 
 	@Override
 	public int getMaxEnergyStored()
 	{
-		return (int)Math.round(getItem().getMaxEnergy(getStack())*general.TO_FORGE);
+		return clampToInt(Math.round(getItem().getMaxEnergy(getStack())*general.TO_FORGE));
 	}
 
 	@Override

--- a/src/main/java/mekanism/common/integration/tesla/TeslaItemWrapper.java
+++ b/src/main/java/mekanism/common/integration/tesla/TeslaItemWrapper.java
@@ -73,17 +73,26 @@ public class TeslaItemWrapper extends ItemCapability implements ITeslaHolder, IT
 		return 0;
 	}
 
+	private static long clampToLong(double d) {
+		// Not using Math.min because it makes you cast things wrong
+		if(d < Long.MAX_VALUE) {
+			return (long)d;
+		} else {
+			return Long.MAX_VALUE;
+		}
+	}
+
 	@Override
 	@Method(modid = MekanismHooks.TESLA_MOD_ID)
 	public long getStoredPower() 
 	{
-		return (long)Math.round(getItem().getEnergy(getStack())*general.TO_TESLA);
+		return clampToLong(Math.round(getItem().getEnergy(getStack())*general.TO_TESLA));
 	}
 
 	@Override
 	@Method(modid = MekanismHooks.TESLA_MOD_ID)
 	public long getCapacity() 
 	{
-		return (long)Math.round(getItem().getEnergy(getStack())*general.TO_TESLA);
+		return clampToLong(Math.round(getItem().getEnergy(getStack())*general.TO_TESLA));
 	}
 }


### PR DESCRIPTION
One example of what this fixes is the Creative Energy Cube showing "-1 RF"
and confusing a lot of other mods.