### PR TITLE
move log on cardboard box blacklist outside loop

### DIFF
--- a/src/main/java/mekanism/common/BoxBlacklistParser.java
+++ b/src/main/java/mekanism/common/BoxBlacklistParser.java
@@ -88,8 +88,8 @@ public final class BoxBlacklistParser
 				MekanismAPI.addBoxBlacklist(block, Integer.parseInt(split[split.length-1]));
 				entries++;
 
-				Mekanism.logger.info("Finished loading Cardboard Box blacklist (loaded " + entries + " entries)");
 			}
+			Mekanism.logger.info("Finished loading Cardboard Box blacklist (loaded " + entries + " entries)");
 		}
 	}
 


### PR DESCRIPTION
Prevents the log from being spammed with messages about this.