### PR TITLE
Fix dupe bug with factories

### DIFF
--- a/src/main/java/mekanism/common/tile/TileEntityFactory.java
+++ b/src/main/java/mekanism/common/tile/TileEntityFactory.java
@@ -447,7 +447,12 @@ public class TileEntityFactory extends TileEntityNoisyElectricBlock implements I
 
 			for(int id : inputSlots)
 			{
-				invStacks.add(InvID.get(id, inventory));
+				InvID item = InvID.get(id, inventory);
+				if(item.stack != null && item.stack.hasTagCompound())
+				{
+					return; //Don't sort items with NBT data (dupe fix)
+				}
+				invStacks.add(item);
 			}
 
 			for(InvID invID1 : invStacks)


### PR DESCRIPTION
This is a simple fix for a dupe bug which involves sorting items which contain inventories where the inventories would copy to the other items when sorting is being done. This fixes that by simply disabling sorting for items which have NBT data.

I only tested this on 1.7.10 but it may be an issue on other versions as well