### PR TITLE
fix crash with dank/null due to UnsupportedOperationException

### DIFF
--- a/src/main/java/mekanism/client/render/item/CustomItemModelFactory.java
+++ b/src/main/java/mekanism/client/render/item/CustomItemModelFactory.java
@@ -53,7 +53,7 @@ public class CustomItemModelFactory implements IBakedModel
 	@Override
 	public boolean isBuiltInRenderer() 
 	{
-		throw new UnsupportedOperationException();
+		return false;
 	}
 
 	@Override
@@ -62,11 +62,6 @@ public class CustomItemModelFactory implements IBakedModel
 		throw new UnsupportedOperationException();
 	}
 
-	@Override
-	public ItemCameraTransforms getItemCameraTransforms() 
-	{
-		throw new UnsupportedOperationException();
-	}
 	
     private class MachineOverride extends ItemOverrideList 
     {


### PR DESCRIPTION
Placing an energy cube in a Dank/Null causes the client to crash because of a couple UnsupportedOperationExceptions in CustomItemModelFactory.java.  Based on the instructions in the [forge documentation](https://mcforge.readthedocs.io/en/latest/models/advanced/ibakedmodel/) I made isBuiltInRenderer() return false and removed getItemCameraTransforms altogether because it exists in IBakedModel.  I was not able to find any problems after making these changes but if the exceptions existed for a reason that is still relevant I can try and fix it another way.  

A crash log of the problem can be found [here ](https://paste.dimdev.org/ucohilemov.mccrash) btw.  It's not particularly relevant because its fixed now, but if you're curious its there.  