### PR TITLE
Fix #5290; do a double-block update for cardboard boxes

### DIFF
--- a/src/main/java/mekanism/common/item/ItemBlockCardboardBox.java
+++ b/src/main/java/mekanism/common/item/ItemBlockCardboardBox.java
@@ -104,7 +104,12 @@ public class ItemBlockCardboardBox extends ItemBlock
 					stack.shrink(1);
 				}
 
-				world.setBlockState(pos, MekanismBlocks.CardboardBox.getStateFromMeta(1), 3);
+				// First, set the block to air to give the underlying block a chance to process
+				// any updates (esp. if it's a tile entity backed block). Ideally, we could avoid
+				// double updates, but if the block we are wrapping has multiple stacked blocks,
+				// we need to make sure it has a chance to update.
+				world.setBlockToAir(pos);
+				world.setBlockState(pos, MekanismBlocks.CardboardBox.getStateFromMeta(1));
 
 				isMonitoring = false;
 


### PR DESCRIPTION
The problem is that IE actually triggers it's own setBlockState whenever a cloche (or other double-high block) is broken - the work around is to first set the block in question to air, then place the cardboard box. Ideally we wouldn't have to do this two-step, but double-blocks are such a hack that I think this is a reasonable tradeoff.